### PR TITLE
Rename the assert function to `#expect` and leave the original `#powerAssert` function as an alias for `#expect`.

### DIFF
--- a/Sources/PowerAssert/Macros.swift
+++ b/Sources/PowerAssert/Macros.swift
@@ -1,4 +1,22 @@
-@freestanding(expression) public macro powerAssert(
+/// Asserts that the given expression is true.
+/// - Parameters:
+///   - expression: The expression to evaluate.
+///   - message: An optional description of a failure.
+///   - file: The file where the failure occurs. The default is the filename of the test case where you call this function.
+///   - line: The line number where the failure occurs. The default is the line number where you call this function.
+///   - verbose: If `true`, the result is always printed instead of only when the assertion fails.
+@freestanding(expression)
+public macro expect(
+    _ expression: @autoclosure () throws -> Bool,
+    _ message: @autoclosure () -> String = "",
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    verbose: Bool = false
+) = #externalMacro(module: "PowerAssertPlugin", type: "PowerAssertMacro")
+
+/// An alias for `expect`.
+@freestanding(expression)
+public macro powerAssert(
   _ expression: @autoclosure () throws -> Bool,
   _ message: @autoclosure () -> String = "",
   file: StaticString = #filePath,

--- a/Tests/PowerAssertTests.swift
+++ b/Tests/PowerAssertTests.swift
@@ -5,19 +5,19 @@ final class PowerAssertTests: XCTestCase {
   func testBinaryExpression1() {
     captureConsoleOutput {
       let bar = Bar(foo: Foo(val: 2), val: 3)
-      #powerAssert(bar.val != bar.foo.val, verbose: true)
+      #expect(bar.val != bar.foo.val, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(bar.val != bar.foo.val)
-                     |   |   |  |   |   |
-                     |   3   |  |   |   2
-                     |       |  |   Foo(val: 2)
-                     |       |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                     |       true
-                     Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+        #expect(bar.val != bar.foo.val)
+                |   |   |  |   |   |
+                |   3   |  |   |   2
+                |       |  |   Foo(val: 2)
+                |       |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                |       true
+                Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
 
         """
       )
@@ -27,19 +27,19 @@ final class PowerAssertTests: XCTestCase {
   func testBinaryExpression2() {
     captureConsoleOutput {
       let bar = Bar(foo: Foo(val: 2), val: 3)
-      #powerAssert(bar.val > bar.foo.val, verbose: true)
+      #expect(bar.val > bar.foo.val, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(bar.val > bar.foo.val)
-                     |   |   | |   |   |
-                     |   3   | |   |   2
-                     |       | |   Foo(val: 2)
-                     |       | Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                     |       true
-                     Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+        #expect(bar.val > bar.foo.val)
+                |   |   | |   |   |
+                |   3   | |   |   2
+                |       | |   Foo(val: 2)
+                |       | Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                |       true
+                Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
 
         """
       )
@@ -54,16 +54,16 @@ final class PowerAssertTests: XCTestCase {
       let three = 3
 
       let array = [one, two, three]
-      #powerAssert(array.firstIndex(of: zero) != two, verbose: true)
+      #expect(array.firstIndex(of: zero) != two, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array.firstIndex(of: zero) != two)
-                     |     |              |     |  |
-                     |     nil            0     |  Optional(2)
-                     [1, 2, 3]                  true
+        #expect(array.firstIndex(of: zero) != two)
+                |     |              |     |  |
+                |     nil            0     |  Optional(2)
+                [1, 2, 3]                  true
 
         """
       )
@@ -77,17 +77,17 @@ final class PowerAssertTests: XCTestCase {
       let three = 3
 
       let array = [one, two, three]
-      #powerAssert(array.description.hasPrefix("[") == true && array.description.hasPrefix("Hello") == false, verbose: true)
+      #expect(array.description.hasPrefix("[") == true && array.description.hasPrefix("Hello") == false, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array.description.hasPrefix("[") == true && array.description.hasPrefix("Hello") == false)
-                     |     |           |         |    |  |    |  |     |           |         |        |  |
-                     |     "[1, 2, 3]" true      "["  |  true |  |     "[1, 2, 3]" false     "Hello"  |  false
-                     [1, 2, 3]                        true    |  [1, 2, 3]                            true
-                                                              true
+        #expect(array.description.hasPrefix("[") == true && array.description.hasPrefix("Hello") == false)
+                |     |           |         |    |  |    |  |     |           |         |        |  |
+                |     "[1, 2, 3]" true      "["  |  true |  |     "[1, 2, 3]" false     "Hello"  |  false
+                [1, 2, 3]                        true    |  [1, 2, 3]                            true
+                                                         true
 
         """
       )
@@ -104,22 +104,22 @@ final class PowerAssertTests: XCTestCase {
       let array = [one, two, three]
 
       let bar = Bar(foo: Foo(val: 2), val: 3)
-      #powerAssert(array.firstIndex(of: zero) != two && bar.val != bar.foo.val, verbose: true)
+      #expect(array.firstIndex(of: zero) != two && bar.val != bar.foo.val, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array.firstIndex(of: zero) != two && bar.val != bar.foo.val)
-                     |     |              |     |  |   |  |   |   |  |   |   |
-                     |     nil            0     |  |   |  |   3   |  |   |   2
-                     [1, 2, 3]                  |  |   |  |       |  |   Foo(val: 2)
-                                                |  |   |  |       |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                                                |  |   |  |       true
-                                                |  |   |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                                                |  |   true
-                                                |  Optional(2)
-                                                true
+        #expect(array.firstIndex(of: zero) != two && bar.val != bar.foo.val)
+                |     |              |     |  |   |  |   |   |  |   |   |
+                |     nil            0     |  |   |  |   3   |  |   |   2
+                [1, 2, 3]                  |  |   |  |       |  |   Foo(val: 2)
+                                           |  |   |  |       |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                                           |  |   |  |       true
+                                           |  |   |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                                           |  |   true
+                                           |  Optional(2)
+                                           true
 
         """
       )
@@ -133,16 +133,16 @@ final class PowerAssertTests: XCTestCase {
       let three = 3
 
       let array = [one, two, three]
-      #powerAssert(array.distance(from: 2, to: 3) == 1, verbose: true)
+      #expect(array.distance(from: 2, to: 3) == 1, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array.distance(from: 2, to: 3) == 1)
-                     |     |              |      |  |  |
-                     |     1              2      3  |  1
-                     [1, 2, 3]                      true
+        #expect(array.distance(from: 2, to: 3) == 1)
+                |     |              |      |  |  |
+                |     1              2      3  |  1
+                [1, 2, 3]                      true
 
         """
       )
@@ -155,16 +155,16 @@ final class PowerAssertTests: XCTestCase {
       let two = 2
       let three = 3
 
-      #powerAssert([one, two, three].count == 3, verbose: true)
+      #expect([one, two, three].count == 3, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert([one, two, three].count == 3)
-                     ||    |    |      |     |  |
-                     |1    2    3      3     |  3
-                     [1, 2, 3]               true
+        #expect([one, two, three].count == 3)
+                ||    |    |      |     |  |
+                |1    2    3      3     |  3
+                [1, 2, 3]               true
 
         """
       )
@@ -181,22 +181,22 @@ final class PowerAssertTests: XCTestCase {
 
       let object = Object(types: types)
 
-      #powerAssert((object.types[index] as! Person).name != bob.name, verbose: true)
+      #expect((object.types[index] as! Person).name != bob.name, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert((object.types[index] as! Person).name != bob.name)
-                     ||      |     |    |             |    |  |   |
-                     ||      |     7    |             |    |  |   "bob"
-                     ||      |          |             |    |  Person(name: "bob", age: 5)
-                     ||      |          |             |    true
-                     ||      |          |             "alice"
-                     ||      |          Optional(PowerAssertTests.Person(name: "alice", age: 3))
-                     ||      [Optional("string"), Optional(98.6), Optional(true), Optional(false), nil, Optional(nan), Optional(inf), Optional(PowerAssertTests.Person(name: "alice", age: 3))]
-                     |Object(types: [Optional("string"), Optional(98.6), Optional(true), Optional(false), nil, Optional(nan), Optional(inf), Optional(PowerAssertTests.Person(name: "alice", age: 3))])
-                     Person(name: "alice", age: 3)
+        #expect((object.types[index] as! Person).name != bob.name)
+                ||      |     |    |             |    |  |   |
+                ||      |     7    |             |    |  |   "bob"
+                ||      |          |             |    |  Person(name: "bob", age: 5)
+                ||      |          |             |    true
+                ||      |          |             "alice"
+                ||      |          Optional(PowerAssertTests.Person(name: "alice", age: 3))
+                ||      [Optional("string"), Optional(98.6), Optional(true), Optional(false), nil, Optional(nan), Optional(inf), Optional(PowerAssertTests.Person(name: "alice", age: 3))]
+                |Object(types: [Optional("string"), Optional(98.6), Optional(true), Optional(false), nil, Optional(nan), Optional(inf), Optional(PowerAssertTests.Person(name: "alice", age: 3))])
+                Person(name: "alice", age: 3)
 
         """
       )
@@ -210,17 +210,17 @@ final class PowerAssertTests: XCTestCase {
       let three = 3
 
       let array = [one, two, three]
-      #powerAssert(array.description.hasPrefix("]") == true || array.description.hasPrefix("Hello") == false, verbose: true)
+      #expect(array.description.hasPrefix("]") == true || array.description.hasPrefix("Hello") == false, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array.description.hasPrefix("]") == true || array.description.hasPrefix("Hello") == false)
-                     |     |           |         |    |  |    |  |     |           |         |        |  |
-                     |     "[1, 2, 3]" false     "]"  |  true |  |     "[1, 2, 3]" false     "Hello"  |  false
-                     [1, 2, 3]                        false   |  [1, 2, 3]                            true
-                                                              true
+        #expect(array.description.hasPrefix("]") == true || array.description.hasPrefix("Hello") == false)
+                |     |           |         |    |  |    |  |     |           |         |        |  |
+                |     "[1, 2, 3]" false     "]"  |  true |  |     "[1, 2, 3]" false     "Hello"  |  false
+                [1, 2, 3]                        false   |  [1, 2, 3]                            true
+                                                         true
 
         """
       )
@@ -231,11 +231,11 @@ final class PowerAssertTests: XCTestCase {
     captureConsoleOutput {
       let bar = Bar(foo: Foo(val: 2), val: 3)
 
-      #powerAssert(bar.val != bar.foo.val, verbose: true)
-      #powerAssert(bar
+      #expect(bar.val != bar.foo.val, verbose: true)
+      #expect(bar
         .val !=
              bar.foo.val, verbose: true)
-      #powerAssert(bar
+      #expect(bar
         .val !=
              bar
         .foo        .val, verbose: true)
@@ -244,27 +244,27 @@ final class PowerAssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         """
-        #powerAssert(bar.val != bar.foo.val)
-                     |   |   |  |   |   |
-                     |   3   |  |   |   2
-                     |       |  |   Foo(val: 2)
-                     |       |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                     |       true
-                     Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-        #powerAssert(bar .val != bar.foo.val)
-                     |    |   |  |   |   |
-                     |    3   |  |   |   2
-                     |        |  |   Foo(val: 2)
-                     |        |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                     |        true
-                     Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-        #powerAssert(bar .val != bar .foo .val)
-                     |    |   |  |    |    |
-                     |    3   |  |    |    2
-                     |        |  |    Foo(val: 2)
-                     |        |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                     |        true
-                     Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+        #expect(bar.val != bar.foo.val)
+                |   |   |  |   |   |
+                |   3   |  |   |   2
+                |       |  |   Foo(val: 2)
+                |       |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                |       true
+                Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+        #expect(bar .val != bar.foo.val)
+                |    |   |  |   |   |
+                |    3   |  |   |   2
+                |        |  |   Foo(val: 2)
+                |        |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                |        true
+                Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+        #expect(bar .val != bar .foo .val)
+                |    |   |  |    |    |
+                |    3   |  |    |    2
+                |        |  |    Foo(val: 2)
+                |        |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                |        true
+                Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
 
         """
       )
@@ -279,13 +279,13 @@ final class PowerAssertTests: XCTestCase {
       let three = 3
       let array = [one, two, three]
 
-      #powerAssert(array    .        firstIndex(
+      #expect(array    .        firstIndex(
         of:    zero)
              != two,
                    verbose: true
       )
 
-      #powerAssert(array
+      #expect(array
         .
                    firstIndex(
 
@@ -296,7 +296,7 @@ final class PowerAssertTests: XCTestCase {
                    ,     verbose: true
       )
 
-      #powerAssert(array
+      #expect(array
         .firstIndex(
           of:
             zero)
@@ -309,18 +309,18 @@ final class PowerAssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array . firstIndex( of: zero) != two)
-                     |       |               |     |  |
-                     |       nil             0     |  Optional(2)
-                     [1, 2, 3]                     true
-        #powerAssert(array . firstIndex( of: zero) != two)
-                     |       |               |     |  |
-                     |       nil             0     |  Optional(2)
-                     [1, 2, 3]                     true
-        #powerAssert(array .firstIndex( of: zero) != two)
-                     |      |               |     |  |
-                     |      nil             0     |  Optional(2)
-                     [1, 2, 3]                    true
+        #expect(array . firstIndex( of: zero) != two)
+                |       |               |     |  |
+                |       nil             0     |  Optional(2)
+                [1, 2, 3]                     true
+        #expect(array . firstIndex( of: zero) != two)
+                |       |               |     |  |
+                |       nil             0     |  Optional(2)
+                [1, 2, 3]                     true
+        #expect(array .firstIndex( of: zero) != two)
+                |      |               |     |  |
+                |      nil             0     |  Optional(2)
+                [1, 2, 3]                    true
 
         """
       )
@@ -334,7 +334,7 @@ final class PowerAssertTests: XCTestCase {
       let three = 3
 
       let array = [one, two, three]
-      #powerAssert(array
+      #expect(array
         .description
         .hasPrefix(    "["
                   )
@@ -348,11 +348,11 @@ final class PowerAssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array .description .hasPrefix( "[" ) == true && array .description .hasPrefix ("Hello" ) == false)
-                     |      |            |          |     |  |    |  |      |            |          |         |  |
-                     |      "[1, 2, 3]"  true       "["   |  true |  |      "[1, 2, 3]"  false      "Hello"   |  false
-                     [1, 2, 3]                            true    |  [1, 2, 3]                                true
-                                                                  true
+        #expect(array .description .hasPrefix( "[" ) == true && array .description .hasPrefix ("Hello" ) == false)
+                |      |            |          |     |  |    |  |      |            |          |         |  |
+                |      "[1, 2, 3]"  true       "["   |  true |  |      "[1, 2, 3]"  false      "Hello"   |  false
+                [1, 2, 3]                            true    |  [1, 2, 3]                                true
+                                                             true
 
         """
       )
@@ -370,7 +370,7 @@ final class PowerAssertTests: XCTestCase {
 
       let bar = Bar(foo: Foo(val: 2), val: 3)
 
-      #powerAssert(
+      #expect(
 
         array.firstIndex(
           of: zero
@@ -389,16 +389,16 @@ final class PowerAssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array.firstIndex( of: zero ) != two && bar .val != bar .foo .val)
-                     |     |               |      |  |   |  |    |   |  |    |    |
-                     |     nil             0      |  |   |  |    3   |  |    |    2
-                     [1, 2, 3]                    |  |   |  |        |  |    Foo(val: 2)
-                                                  |  |   |  |        |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                                                  |  |   |  |        true
-                                                  |  |   |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                                                  |  |   true
-                                                  |  Optional(2)
-                                                  true
+        #expect(array.firstIndex( of: zero ) != two && bar .val != bar .foo .val)
+                |     |               |      |  |   |  |    |   |  |    |    |
+                |     nil             0      |  |   |  |    3   |  |    |    2
+                [1, 2, 3]                    |  |   |  |        |  |    Foo(val: 2)
+                                             |  |   |  |        |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                                             |  |   |  |        true
+                                             |  |   |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                                             |  |   true
+                                             |  Optional(2)
+                                             true
 
         """
       )
@@ -412,7 +412,7 @@ final class PowerAssertTests: XCTestCase {
       let three = 3
 
       let array = [one, two, three]
-      #powerAssert(
+      #expect(
 
         array
           .distance(
@@ -425,10 +425,10 @@ final class PowerAssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array .distance( from: 2, to: 3) != 4)
-                     |      |               |      |  |  |
-                     |      1               2      3  |  4
-                     [1, 2, 3]                        true
+        #expect(array .distance( from: 2, to: 3) != 4)
+                |      |               |      |  |  |
+                |      1               2      3  |  4
+                [1, 2, 3]                        true
 
         """
       )
@@ -441,7 +441,7 @@ final class PowerAssertTests: XCTestCase {
       let two = 2
       let three = 3
 
-      #powerAssert([one,
+      #expect([one,
               two
               , three]
         .count
@@ -452,10 +452,10 @@ final class PowerAssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         """
-        #powerAssert([one, two , three] .count != 10)
-                     ||    |     |       |     |  |
-                     |1    2     3       3     |  10
-                     [1, 2, 3]                 true
+        #expect([one, two , three] .count != 10)
+                ||    |     |       |     |  |
+                |1    2     3       3     |  10
+                [1, 2, 3]                 true
 
         """
       )
@@ -470,15 +470,15 @@ final class PowerAssertTests: XCTestCase {
         location: Coordinate(latitude: 35.658581, longitude: 139.745438)
       )
 
-      #powerAssert(
+      #expect(
         try! JSONEncoder().encode(landmark) != #"{"name":"Tokyo Tower"}"#.data(using: String.Encoding.utf8),
         verbose: true
       )
-      #powerAssert(
+      #expect(
         try! JSONEncoder().encode(landmark) == #"{"name":"Tokyo Tower","location":{"longitude":139.74543800000001,"latitude":35.658580999999998},"foundingYear":1957}"#.data(using: .utf8),
         verbose: true
       )
-      #powerAssert(
+      #expect(
         try! #"{"name":"Tokyo Tower"}"#.data(using: String.Encoding.utf8) != JSONEncoder().encode(landmark),
         verbose: true
       )
@@ -487,31 +487,31 @@ final class PowerAssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         #"""
-        #powerAssert(try! JSONEncoder().encode(landmark) != #"{"name":"Tokyo Tower"}"#.data(using: String.Encoding.utf8))
-                          |             |      |         |  |                          |           |      |        |
-                          |             |      |         |  |                          |           String Encoding Unicode (UTF-8)
-                          |             |      |         |  |                          Optional(22 bytes)
-                          |             |      |         |  "{\"name\":\"Tokyo Tower\"}"
-                          |             |      |         true
-                          |             |      Landmark(name: "Tokyo Tower", foundingYear: 1957, location: PowerAssertTests.Coordinate(latitude: 35.658581, longitude: 139.745438))
-                          |             Optional(116 bytes)
-                          Foundation.JSONEncoder
-        #powerAssert(try! JSONEncoder().encode(landmark) == #"{"name":"Tokyo Tower","location":{"longitude":139.74543800000001,"latitude":35.658580999999998},"foundingYear":1957}"#.data(using: .utf8))
-                          |             |      |         |  |                                                                                                                        |            |
-                          |             |      |         |  |                                                                                                                        |            Unicode (UTF-8)
-                          |             |      |         |  |                                                                                                                        Optional(116 bytes)
-                          |             |      |         |  "{\"name\":\"Tokyo Tower\",\"location\":{\"longitude\":139.74543800000001,\"latitude\":35.658580999999998},\"foundingYear\":1957}"
-                          |             |      |         true
-                          |             |      Landmark(name: "Tokyo Tower", foundingYear: 1957, location: PowerAssertTests.Coordinate(latitude: 35.658581, longitude: 139.745438))
-                          |             Optional(116 bytes)
-                          Foundation.JSONEncoder
-        #powerAssert(try! #"{"name":"Tokyo Tower"}"#.data(using: String.Encoding.utf8) != JSONEncoder().encode(landmark))
-                          |                          |           |      |        |     |  |             |      |
-                          |                          |           String Encoding |     |  |             |      Landmark(name: "Tokyo Tower", foundingYear: 1957, location: PowerAssertTests.Coordinate(latitude: 35.658581, longitude: 139.745438))
-                          |                          Optional(22 bytes)          |     |  |             Optional(116 bytes)
-                          "{\"name\":\"Tokyo Tower\"}"                           |     |  Foundation.JSONEncoder
-                                                                                 |     true
-                                                                                 Unicode (UTF-8)
+        #expect(try! JSONEncoder().encode(landmark) != #"{"name":"Tokyo Tower"}"#.data(using: String.Encoding.utf8))
+                     |             |      |         |  |                          |           |      |        |
+                     |             |      |         |  |                          |           String Encoding Unicode (UTF-8)
+                     |             |      |         |  |                          Optional(22 bytes)
+                     |             |      |         |  "{\"name\":\"Tokyo Tower\"}"
+                     |             |      |         true
+                     |             |      Landmark(name: "Tokyo Tower", foundingYear: 1957, location: PowerAssertTests.Coordinate(latitude: 35.658581, longitude: 139.745438))
+                     |             Optional(116 bytes)
+                     Foundation.JSONEncoder
+        #expect(try! JSONEncoder().encode(landmark) == #"{"name":"Tokyo Tower","location":{"longitude":139.74543800000001,"latitude":35.658580999999998},"foundingYear":1957}"#.data(using: .utf8))
+                     |             |      |         |  |                                                                                                                        |            |
+                     |             |      |         |  |                                                                                                                        |            Unicode (UTF-8)
+                     |             |      |         |  |                                                                                                                        Optional(116 bytes)
+                     |             |      |         |  "{\"name\":\"Tokyo Tower\",\"location\":{\"longitude\":139.74543800000001,\"latitude\":35.658580999999998},\"foundingYear\":1957}"
+                     |             |      |         true
+                     |             |      Landmark(name: "Tokyo Tower", foundingYear: 1957, location: PowerAssertTests.Coordinate(latitude: 35.658581, longitude: 139.745438))
+                     |             Optional(116 bytes)
+                     Foundation.JSONEncoder
+        #expect(try! #"{"name":"Tokyo Tower"}"#.data(using: String.Encoding.utf8) != JSONEncoder().encode(landmark))
+                     |                          |           |      |        |     |  |             |      |
+                     |                          |           String Encoding |     |  |             |      Landmark(name: "Tokyo Tower", foundingYear: 1957, location: PowerAssertTests.Coordinate(latitude: 35.658581, longitude: 139.745438))
+                     |                          Optional(22 bytes)          |     |  |             Optional(116 bytes)
+                     "{\"name\":\"Tokyo Tower\"}"                           |     |  Foundation.JSONEncoder
+                                                                            |     true
+                                                                            Unicode (UTF-8)
 
         """#
       )
@@ -523,19 +523,19 @@ final class PowerAssertTests: XCTestCase {
       let string = "1234"
       let number = Int(string)
 
-      #powerAssert(number != nil && number == 1234, verbose: true)
+      #expect(number != nil && number == 1234, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(number != nil && number == 1234)
-                     |      |  |   |  |      |  |
-                     |      |  nil |  |      |  Optional(1234)
-                     |      true   |  |      true
-                     |             |  Optional(1234)
-                     |             true
-                     Optional(1234)
+        #expect(number != nil && number == 1234)
+                |      |  |   |  |      |  |
+                |      |  nil |  |      |  Optional(1234)
+                |      true   |  |      true
+                |             |  Optional(1234)
+                |             true
+                Optional(1234)
 
         """
       )
@@ -548,18 +548,18 @@ final class PowerAssertTests: XCTestCase {
       let number = Int(string)
       let hello = "hello"
 
-      #powerAssert((number != nil ? string : hello) == string, verbose: true)
+      #expect((number != nil ? string : hello) == string, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert((number != nil ? string : hello) == string)
-                     |||     |  |     |               |  |
-                     ||"1234"|  nil   "1234"          |  "1234"
-                     ||      true                     true
-                     |Optional(1234)
-                     "1234"
+        #expect((number != nil ? string : hello) == string)
+                |||     |  |     |               |  |
+                ||"1234"|  nil   "1234"          |  "1234"
+                ||      true                     true
+                |Optional(1234)
+                "1234"
 
         """
       )
@@ -572,19 +572,19 @@ final class PowerAssertTests: XCTestCase {
       let number = Int(string)
       let hello = "hello"
 
-      #powerAssert((number == nil ? string : hello) != string, verbose: true)
+      #expect((number == nil ? string : hello) != string, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert((number == nil ? string : hello) != string)
-                     |||     |  |              |      |  |
-                     |||     |  nil            |      |  "1234"
-                     |||     false             |      true
-                     ||"hello"                 "hello"
-                     |Optional(1234)
-                     "hello"
+        #expect((number == nil ? string : hello) != string)
+                |||     |  |              |      |  |
+                |||     |  nil            |      |  "1234"
+                |||     false             |      true
+                ||"hello"                 "hello"
+                |Optional(1234)
+                "hello"
 
         """
       )
@@ -598,16 +598,16 @@ final class PowerAssertTests: XCTestCase {
       let two = 2
       let three = 3
 
-      #powerAssert([one, two, three].firstIndex(of: zero) != two, verbose: true)
+      #expect([one, two, three].firstIndex(of: zero) != two, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert([one, two, three].firstIndex(of: zero) != two)
-                     ||    |    |      |              |     |  |
-                     |1    2    3      nil            0     |  Optional(2)
-                     [1, 2, 3]                              true
+        #expect([one, two, three].firstIndex(of: zero) != two)
+                ||    |    |      |              |     |  |
+                |1    2    3      nil            0     |  Optional(2)
+                [1, 2, 3]                              true
 
         """
       )
@@ -621,26 +621,26 @@ final class PowerAssertTests: XCTestCase {
       let two = 2
       let three = 3
 
-      #powerAssert([zero: one, two: three].count != three, verbose: true)
+      #expect([zero: one, two: three].count != three, verbose: true)
     } completion: { (output) in
       print(output)
       // Dictionary order is not guaranteed
       XCTAssertTrue(
         output ==
         """
-        #powerAssert([zero: one, two: three].count != three)
-                     ||     |    |    |      |     |  |
-                     |0     1    2    3      2     |  3
-                     [0: 1, 2: 3]                  true
+        #expect([zero: one, two: three].count != three)
+                ||     |    |    |      |     |  |
+                |0     1    2    3      2     |  3
+                [0: 1, 2: 3]                  true
 
         """
         ||
         output ==
         """
-        #powerAssert([zero: one, two: three].count != three)
-                     ||     |    |    |      |     |  |
-                     |0     1    2    3      2     |  3
-                     [2: 3, 0: 1]                  true
+        #expect([zero: one, two: three].count != three)
+                ||     |    |    |      |     |  |
+                |0     1    2    3      2     |  3
+                [2: 3, 0: 1]                  true
 
         """
       )
@@ -699,29 +699,29 @@ final class PowerAssertTests: XCTestCase {
 
   func testSelfExpression() {
     captureConsoleOutput {
-      #powerAssert(
+      #expect(
         self.stringValue == "string" && self.intValue == 100 && self.doubleValue == 999.9,
         verbose: true
       )
-      #powerAssert(super.continueAfterFailure == true, verbose: true)
+      #expect(super.continueAfterFailure == true, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(self.stringValue == "string" && self.intValue == 100 && self.doubleValue == 999.9)
-                     |    |           |  |        |  |    |        |  |   |  |    |           |  |
-                     |    "string"    |  "string" |  |    100      |  100 |  |    999.9       |  999.9
-                     |                true        |  |             true   |  |                true
-                     |                            |  |                    |  -[PowerAssertTests testSelfExpression]
-                     |                            |  |                    true
-                     |                            |  -[PowerAssertTests testSelfExpression]
-                     |                            true
-                     -[PowerAssertTests testSelfExpression]
-        #powerAssert(super.continueAfterFailure == true)
-                           |                    |  |
-                           true                 |  true
-                                                true
+        #expect(self.stringValue == "string" && self.intValue == 100 && self.doubleValue == 999.9)
+                |    |           |  |        |  |    |        |  |   |  |    |           |  |
+                |    "string"    |  "string" |  |    100      |  100 |  |    999.9       |  999.9
+                |                true        |  |             true   |  |                true
+                |                            |  |                    |  -[PowerAssertTests testSelfExpression]
+                |                            |  |                    true
+                |                            |  -[PowerAssertTests testSelfExpression]
+                |                            true
+                -[PowerAssertTests testSelfExpression]
+        #expect(super.continueAfterFailure == true)
+                      |                    |  |
+                      true                 |  true
+                                           true
 
         """
       )
@@ -731,55 +731,55 @@ final class PowerAssertTests: XCTestCase {
   func testImplicitMemberExpression() {
     captureConsoleOutput {
       let i = 64
-      #powerAssert(i == .bitWidth && i == Double.Exponent.bitWidth, verbose: true)
+      #expect(i == .bitWidth && i == Double.Exponent.bitWidth, verbose: true)
 
       let mask: CAAutoresizingMask = [.layerMaxXMargin, .layerMaxYMargin]
-      #powerAssert(mask == [CAAutoresizingMask.layerMaxXMargin, CAAutoresizingMask.layerMaxYMargin], verbose: true)
+      #expect(mask == [CAAutoresizingMask.layerMaxXMargin, CAAutoresizingMask.layerMaxYMargin], verbose: true)
 
-      #powerAssert(mask == [CAAutoresizingMask.layerMaxXMargin, .layerMaxYMargin], verbose: true)
+      #expect(mask == [CAAutoresizingMask.layerMaxXMargin, .layerMaxYMargin], verbose: true)
 
-      #powerAssert(mask == [.layerMaxXMargin, CAAutoresizingMask.layerMaxYMargin], verbose: true)
+      #expect(mask == [.layerMaxXMargin, CAAutoresizingMask.layerMaxYMargin], verbose: true)
 
-      #powerAssert(mask == [.layerMaxXMargin, .layerMaxYMargin], verbose: true)
+      #expect(mask == [.layerMaxXMargin, .layerMaxYMargin], verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(i == .bitWidth && i == Double.Exponent.bitWidth)
-                     | |   |        |  | |  |      |        |
-                     | |   64       |  | |  Double Int      64
-                     | true         |  | true
-                     64             |  64
-                                    true
-        #powerAssert(mask == [CAAutoresizingMask.layerMaxXMargin, CAAutoresizingMask.layerMaxYMargin])
-                     |    |  ||                  |                |                  |
-                     |    |  |CAAutoresizingMask |                CAAutoresizingMask CAAutoresizingMask(rawValue: 32)
-                     |    |  |                   CAAutoresizingMask(rawValue: 4)
-                     |    |  CAAutoresizingMask(rawValue: 36)
-                     |    true
-                     CAAutoresizingMask(rawValue: 36)
-        #powerAssert(mask == [CAAutoresizingMask.layerMaxXMargin, .layerMaxYMargin])
-                     |    |  ||                  |                 |
-                     |    |  |CAAutoresizingMask |                 CAAutoresizingMask(rawValue: 32)
-                     |    |  |                   CAAutoresizingMask(rawValue: 4)
-                     |    |  CAAutoresizingMask(rawValue: 36)
-                     |    true
-                     CAAutoresizingMask(rawValue: 36)
-        #powerAssert(mask == [.layerMaxXMargin, CAAutoresizingMask.layerMaxYMargin])
-                     |    |  | |                |                  |
-                     |    |  | |                CAAutoresizingMask CAAutoresizingMask(rawValue: 32)
-                     |    |  | CAAutoresizingMask(rawValue: 4)
-                     |    |  CAAutoresizingMask(rawValue: 36)
-                     |    true
-                     CAAutoresizingMask(rawValue: 36)
-        #powerAssert(mask == [.layerMaxXMargin, .layerMaxYMargin])
-                     |    |  | |                 |
-                     |    |  | |                 CAAutoresizingMask(rawValue: 32)
-                     |    |  | CAAutoresizingMask(rawValue: 4)
-                     |    |  CAAutoresizingMask(rawValue: 36)
-                     |    true
-                     CAAutoresizingMask(rawValue: 36)
+        #expect(i == .bitWidth && i == Double.Exponent.bitWidth)
+                | |   |        |  | |  |      |        |
+                | |   64       |  | |  Double Int      64
+                | true         |  | true
+                64             |  64
+                               true
+        #expect(mask == [CAAutoresizingMask.layerMaxXMargin, CAAutoresizingMask.layerMaxYMargin])
+                |    |  ||                  |                |                  |
+                |    |  |CAAutoresizingMask |                CAAutoresizingMask CAAutoresizingMask(rawValue: 32)
+                |    |  |                   CAAutoresizingMask(rawValue: 4)
+                |    |  CAAutoresizingMask(rawValue: 36)
+                |    true
+                CAAutoresizingMask(rawValue: 36)
+        #expect(mask == [CAAutoresizingMask.layerMaxXMargin, .layerMaxYMargin])
+                |    |  ||                  |                 |
+                |    |  |CAAutoresizingMask |                 CAAutoresizingMask(rawValue: 32)
+                |    |  |                   CAAutoresizingMask(rawValue: 4)
+                |    |  CAAutoresizingMask(rawValue: 36)
+                |    true
+                CAAutoresizingMask(rawValue: 36)
+        #expect(mask == [.layerMaxXMargin, CAAutoresizingMask.layerMaxYMargin])
+                |    |  | |                |                  |
+                |    |  | |                CAAutoresizingMask CAAutoresizingMask(rawValue: 32)
+                |    |  | CAAutoresizingMask(rawValue: 4)
+                |    |  CAAutoresizingMask(rawValue: 36)
+                |    true
+                CAAutoresizingMask(rawValue: 36)
+        #expect(mask == [.layerMaxXMargin, .layerMaxYMargin])
+                |    |  | |                 |
+                |    |  | |                 CAAutoresizingMask(rawValue: 32)
+                |    |  | CAAutoresizingMask(rawValue: 4)
+                |    |  CAAutoresizingMask(rawValue: 36)
+                |    true
+                CAAutoresizingMask(rawValue: 36)
 
         """
       )
@@ -799,35 +799,35 @@ final class PowerAssertTests: XCTestCase {
 
       let tuple = (name: "Katsumi", age: 37, birthday: date1)
 
-      #powerAssert(tuple != (name: "Katsumi", age: 37, birthday: date2), verbose: true)
-      #powerAssert(tuple != ("Katsumi", 37, date2), verbose: true)
-      #powerAssert(tuple.name == ("Katsumi", 37, date2).0 || tuple.age != ("Katsumi", 37, date2).1, verbose: true)
+      #expect(tuple != (name: "Katsumi", age: 37, birthday: date2), verbose: true)
+      #expect(tuple != ("Katsumi", 37, date2), verbose: true)
+      #expect(tuple.name == ("Katsumi", 37, date2).0 || tuple.age != ("Katsumi", 37, date2).1, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(tuple != (name: "Katsumi", age: 37, birthday: date2))
-                     |     |  |      |               |             |
-                     |     |  |      "Katsumi"       37            2000-12-30 15:00:00 +0000
-                     |     |  ("Katsumi", 37, 2000-12-30 15:00:00 +0000)
-                     |     true
-                     ("Katsumi", 37, 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple != ("Katsumi", 37, date2))
-                     |     |  ||          |   |
-                     |     |  |"Katsumi"  37  2000-12-30 15:00:00 +0000
-                     |     |  ("Katsumi", 37, 2000-12-30 15:00:00 +0000)
-                     |     true
-                     ("Katsumi", 37, 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple.name == ("Katsumi", 37, date2).0 || tuple.age != ("Katsumi", 37, date2).1)
-                     |     |    |  ||          |   |      | |
-                     |     |    |  |"Katsumi"  37  |      | true
-                     |     |    |  |               |      "Katsumi"
-                     |     |    |  |               2000-12-30 15:00:00 +0000
-                     |     |    |  ("Katsumi", 37, 2000-12-30 15:00:00 +0000)
-                     |     |    true
-                     |     "Katsumi"
-                     (name: "Katsumi", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+        #expect(tuple != (name: "Katsumi", age: 37, birthday: date2))
+                |     |  |      |               |             |
+                |     |  |      "Katsumi"       37            2000-12-30 15:00:00 +0000
+                |     |  ("Katsumi", 37, 2000-12-30 15:00:00 +0000)
+                |     true
+                ("Katsumi", 37, 1980-10-27 15:00:00 +0000)
+        #expect(tuple != ("Katsumi", 37, date2))
+                |     |  ||          |   |
+                |     |  |"Katsumi"  37  2000-12-30 15:00:00 +0000
+                |     |  ("Katsumi", 37, 2000-12-30 15:00:00 +0000)
+                |     true
+                ("Katsumi", 37, 1980-10-27 15:00:00 +0000)
+        #expect(tuple.name == ("Katsumi", 37, date2).0 || tuple.age != ("Katsumi", 37, date2).1)
+                |     |    |  ||          |   |      | |
+                |     |    |  |"Katsumi"  37  |      | true
+                |     |    |  |               |      "Katsumi"
+                |     |    |  |               2000-12-30 15:00:00 +0000
+                |     |    |  ("Katsumi", 37, 2000-12-30 15:00:00 +0000)
+                |     |    true
+                |     "Katsumi"
+                (name: "Katsumi", age: 37, birthday: 1980-10-27 15:00:00 +0000)
 
         """
       )
@@ -839,16 +839,16 @@ final class PowerAssertTests: XCTestCase {
       let s = SomeStructure(someValue: 12)
       let pathToProperty = \SomeStructure.someValue
 
-      #powerAssert(s[keyPath: pathToProperty] == 12, verbose: true)
-      #powerAssert(s[keyPath: \SomeStructure.someValue] == 12, verbose: true)
-      #powerAssert(s.getValue(keyPath: \.someValue) == 12, verbose: true)
+      #expect(s[keyPath: pathToProperty] == 12, verbose: true)
+      #expect(s[keyPath: \SomeStructure.someValue] == 12, verbose: true)
+      #expect(s.getValue(keyPath: \.someValue) == 12, verbose: true)
 
       let nested = OuterStructure(someValue: 24)
       let nestedKeyPath = \OuterStructure.outer.someValue
 
-      #powerAssert(nested[keyPath: nestedKeyPath] == 24, verbose: true)
-      #powerAssert(nested[keyPath: \OuterStructure.outer.someValue] == 24, verbose: true)
-      #powerAssert(nested.getValue(keyPath: \.outer.someValue) == 24, verbose: true)
+      #expect(nested[keyPath: nestedKeyPath] == 24, verbose: true)
+      #expect(nested[keyPath: \OuterStructure.outer.someValue] == 24, verbose: true)
+      #expect(nested.getValue(keyPath: \.outer.someValue) == 24, verbose: true)
     } completion: { (output) in
       print(output)
 
@@ -856,46 +856,46 @@ final class PowerAssertTests: XCTestCase {
         XCTAssertEqual(
           output,
           #"""
-          #powerAssert(s[keyPath: pathToProperty] == 12)
-                       |          |             | |  |
-                       |          |             | |  12
-                       |          |             | true
-                       |          |             12
-                       |          Swift.WritableKeyPath<PowerAssertTests.SomeStructure, Swift.Int>
-                       SomeStructure(someValue: 12)
-          #powerAssert(s[keyPath: \SomeStructure.someValue] == 12)
-                       |          |                       | |  |
-                       |          |                       | |  12
-                       |          |                       | true
-                       |          |                       12
-                       |          Swift.WritableKeyPath<PowerAssertTests.SomeStructure, Swift.Int>
-                       SomeStructure(someValue: 12)
-          #powerAssert(s.getValue(keyPath: \.someValue) == 12)
-                       | |                 |            |  |
-                       | 12                |            |  12
-                       |                   |            true
-                       |                   Swift.WritableKeyPath<PowerAssertTests.SomeStructure, Swift.Int>
-                       SomeStructure(someValue: 12)
-          #powerAssert(nested[keyPath: nestedKeyPath] == 24)
-                       |               |            | |  |
-                       |               |            | |  24
-                       |               |            | true
-                       |               |            24
-                       |               Swift.WritableKeyPath<PowerAssertTests.OuterStructure, Swift.Int>
-                       OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
-          #powerAssert(nested[keyPath: \OuterStructure.outer.someValue] == 24)
-                       |               |                              | |  |
-                       |               |                              | |  24
-                       |               |                              | true
-                       |               |                              24
-                       |               Swift.WritableKeyPath<PowerAssertTests.OuterStructure, Swift.Int>
-                       OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
-          #powerAssert(nested.getValue(keyPath: \.outer.someValue) == 24)
-                       |      |                 |                  |  |
-                       |      24                |                  |  24
-                       |                        |                  true
-                       |                        Swift.WritableKeyPath<PowerAssertTests.OuterStructure, Swift.Int>
-                       OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
+          #expect(s[keyPath: pathToProperty] == 12)
+                  |          |             | |  |
+                  |          |             | |  12
+                  |          |             | true
+                  |          |             12
+                  |          Swift.WritableKeyPath<PowerAssertTests.SomeStructure, Swift.Int>
+                  SomeStructure(someValue: 12)
+          #expect(s[keyPath: \SomeStructure.someValue] == 12)
+                  |          |                       | |  |
+                  |          |                       | |  12
+                  |          |                       | true
+                  |          |                       12
+                  |          Swift.WritableKeyPath<PowerAssertTests.SomeStructure, Swift.Int>
+                  SomeStructure(someValue: 12)
+          #expect(s.getValue(keyPath: \.someValue) == 12)
+                  | |                 |            |  |
+                  | 12                |            |  12
+                  |                   |            true
+                  |                   Swift.WritableKeyPath<PowerAssertTests.SomeStructure, Swift.Int>
+                  SomeStructure(someValue: 12)
+          #expect(nested[keyPath: nestedKeyPath] == 24)
+                  |               |            | |  |
+                  |               |            | |  24
+                  |               |            | true
+                  |               |            24
+                  |               Swift.WritableKeyPath<PowerAssertTests.OuterStructure, Swift.Int>
+                  OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
+          #expect(nested[keyPath: \OuterStructure.outer.someValue] == 24)
+                  |               |                              | |  |
+                  |               |                              | |  24
+                  |               |                              | true
+                  |               |                              24
+                  |               Swift.WritableKeyPath<PowerAssertTests.OuterStructure, Swift.Int>
+                  OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
+          #expect(nested.getValue(keyPath: \.outer.someValue) == 24)
+                  |      |                 |                  |  |
+                  |      24                |                  |  24
+                  |                        |                  true
+                  |                        Swift.WritableKeyPath<PowerAssertTests.OuterStructure, Swift.Int>
+                  OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
 
           """#
         )
@@ -903,46 +903,46 @@ final class PowerAssertTests: XCTestCase {
         XCTAssertEqual(
           output,
           #"""
-          #powerAssert(s[keyPath: pathToProperty] == 12)
-                       |          |             | |  |
-                       |          |             | |  12
-                       |          |             | true
-                       |          |             12
-                       |          \SomeStructure.someValue
-                       SomeStructure(someValue: 12)
-          #powerAssert(s[keyPath: \SomeStructure.someValue] == 12)
-                       |          |                       | |  |
-                       |          |                       | |  12
-                       |          |                       | true
-                       |          |                       12
-                       |          \SomeStructure.someValue
-                       SomeStructure(someValue: 12)
-          #powerAssert(s.getValue(keyPath: \.someValue) == 12)
-                       | |                 |            |  |
-                       | 12                |            |  12
-                       |                   |            true
-                       |                   \SomeStructure.someValue
-                       SomeStructure(someValue: 12)
-          #powerAssert(nested[keyPath: nestedKeyPath] == 24)
-                       |               |            | |  |
-                       |               |            | |  24
-                       |               |            | true
-                       |               |            24
-                       |               \OuterStructure.outer.someValue
-                       OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
-          #powerAssert(nested[keyPath: \OuterStructure.outer.someValue] == 24)
-                       |               |                              | |  |
-                       |               |                              | |  24
-                       |               |                              | true
-                       |               |                              24
-                       |               \OuterStructure.outer.someValue
-                       OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
-          #powerAssert(nested.getValue(keyPath: \.outer.someValue) == 24)
-                       |      |                 |                  |  |
-                       |      24                |                  |  24
-                       |                        |                  true
-                       |                        \OuterStructure.outer.someValue
-                       OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
+          #expect(s[keyPath: pathToProperty] == 12)
+                  |          |             | |  |
+                  |          |             | |  12
+                  |          |             | true
+                  |          |             12
+                  |          \SomeStructure.someValue
+                  SomeStructure(someValue: 12)
+          #expect(s[keyPath: \SomeStructure.someValue] == 12)
+                  |          |                       | |  |
+                  |          |                       | |  12
+                  |          |                       | true
+                  |          |                       12
+                  |          \SomeStructure.someValue
+                  SomeStructure(someValue: 12)
+          #expect(s.getValue(keyPath: \.someValue) == 12)
+                  | |                 |            |  |
+                  | 12                |            |  12
+                  |                   |            true
+                  |                   \SomeStructure.someValue
+                  SomeStructure(someValue: 12)
+          #expect(nested[keyPath: nestedKeyPath] == 24)
+                  |               |            | |  |
+                  |               |            | |  24
+                  |               |            | true
+                  |               |            24
+                  |               \OuterStructure.outer.someValue
+                  OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
+          #expect(nested[keyPath: \OuterStructure.outer.someValue] == 24)
+                  |               |                              | |  |
+                  |               |                              | |  24
+                  |               |                              | true
+                  |               |                              24
+                  |               \OuterStructure.outer.someValue
+                  OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
+          #expect(nested.getValue(keyPath: \.outer.someValue) == 24)
+                  |      |                 |                  |  |
+                  |      24                |                  |  24
+                  |                        |                  true
+                  |                        \OuterStructure.outer.someValue
+                  OuterStructure(outer: PowerAssertTests.SomeStructure(someValue: 24))
 
           """#
         )
@@ -954,28 +954,28 @@ final class PowerAssertTests: XCTestCase {
     captureConsoleOutput {
       let greetings = ["hello", "hola", "bonjour", "안녕"]
 
-      #powerAssert(greetings[keyPath: \[String].[1]] == "hola", verbose: true)
-      #powerAssert(greetings[keyPath: \[String].first?.count] == 5, verbose: true)
+      #expect(greetings[keyPath: \[String].[1]] == "hola", verbose: true)
+      #expect(greetings[keyPath: \[String].first?.count] == 5, verbose: true)
     } completion: { (output) in
       print(output)
       if ProcessInfo.processInfo.environment["CI"] == "true" {
         XCTAssertEqual(
           output,
           #"""
-          #powerAssert(greetings[keyPath: \[String].[1]] == "hola")
-                       |                  |          | | |  |
-                       |                  |          1 | |  "hola"
-                       |                  |            | true
-                       |                  |            "hola"
-                       |                  Swift.WritableKeyPath<Swift.Array<Swift.String>, Swift.String>
-                       ["hello", "hola", "bonjour", "안녕"]
-          #powerAssert(greetings[keyPath: \[String].first?.count] == 5)
-                       |                  |                     | |  |
-                       |                  |                     | |  Optional(5)
-                       |                  |                     | true
-                       |                  |                     Optional(5)
-                       |                  Swift.KeyPath<Swift.Array<Swift.String>, Swift.Optional<Swift.Int>>
-                       ["hello", "hola", "bonjour", "안녕"]
+          #expect(greetings[keyPath: \[String].[1]] == "hola")
+                  |                  |          | | |  |
+                  |                  |          1 | |  "hola"
+                  |                  |            | true
+                  |                  |            "hola"
+                  |                  Swift.WritableKeyPath<Swift.Array<Swift.String>, Swift.String>
+                  ["hello", "hola", "bonjour", "안녕"]
+          #expect(greetings[keyPath: \[String].first?.count] == 5)
+                  |                  |                     | |  |
+                  |                  |                     | |  Optional(5)
+                  |                  |                     | true
+                  |                  |                     Optional(5)
+                  |                  Swift.KeyPath<Swift.Array<Swift.String>, Swift.Optional<Swift.Int>>
+                  ["hello", "hola", "bonjour", "안녕"]
 
           """#
         )
@@ -983,20 +983,20 @@ final class PowerAssertTests: XCTestCase {
         XCTAssertEqual(
           output,
           #"""
-          #powerAssert(greetings[keyPath: \[String].[1]] == "hola")
-                       |                  |          | | |  |
-                       |                  |          1 | |  "hola"
-                       |                  |            | true
-                       |                  |            "hola"
-                       |                  \Array<String>.<computed 0x00000001a128ad3c (String)>
-                       ["hello", "hola", "bonjour", "안녕"]
-          #powerAssert(greetings[keyPath: \[String].first?.count] == 5)
-                       |                  |                     | |  |
-                       |                  |                     | |  Optional(5)
-                       |                  |                     | true
-                       |                  |                     Optional(5)
-                       |                  \Array<String>.first?.count?
-                       ["hello", "hola", "bonjour", "안녕"]
+          #expect(greetings[keyPath: \[String].[1]] == "hola")
+                  |                  |          | | |  |
+                  |                  |          1 | |  "hola"
+                  |                  |            | true
+                  |                  |            "hola"
+                  |                  \Array<String>.<computed 0x00000001a128ad3c (String)>
+                  ["hello", "hola", "bonjour", "안녕"]
+          #expect(greetings[keyPath: \[String].first?.count] == 5)
+                  |                  |                     | |  |
+                  |                  |                     | |  Optional(5)
+                  |                  |                     | true
+                  |                  |                     Optional(5)
+                  |                  \Array<String>.first?.count?
+                  ["hello", "hola", "bonjour", "안녕"]
 
           """#
         )
@@ -1238,7 +1238,7 @@ final class PowerAssertTests: XCTestCase {
         "triangular": [1, 3, 6, 10, 15, 21, 28],
         "hexagonal": [1, 6, 15, 28, 45, 66, 91]
       ]
-      #powerAssert(
+      #expect(
         interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2,
         verbose: true
       )
@@ -1249,67 +1249,67 @@ final class PowerAssertTests: XCTestCase {
         XCTAssertTrue(
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           Swift.WritableKeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
         )
@@ -1317,7 +1317,7 @@ final class PowerAssertTests: XCTestCase {
         XCTAssertTrue(
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
                        |                           |                 |         | | |  |
                        |                           |                 "prime"   0 2 |  2
                        |                           |                               true
@@ -1328,56 +1328,56 @@ final class PowerAssertTests: XCTestCase {
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
-                       |                           |                 |         | | |  |
-                       |                           |                 "prime"   0 2 |  2
-                       |                           |                               true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["prime"]![0]] == 2)
+                  |                           |                 |         | | |  |
+                  |                           |                 "prime"   0 2 |  2
+                  |                           |                               true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.<computed 0x00000001a128ad3c (Int)>
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
         )
@@ -1392,7 +1392,7 @@ final class PowerAssertTests: XCTestCase {
         "triangular": [1, 3, 6, 10, 15, 21, 28],
         "hexagonal": [1, 6, 15, 28, 45, 66, 91]
       ]
-      #powerAssert(
+      #expect(
         interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7,
         verbose: true
       )
@@ -1403,67 +1403,67 @@ final class PowerAssertTests: XCTestCase {
         XCTAssertTrue(
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
         )
@@ -1471,67 +1471,67 @@ final class PowerAssertTests: XCTestCase {
         XCTAssertTrue(
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
-                       |                           |                 |                  | |  |
-                       |                           |                 "hexagonal"        7 |  7
-                       |                           |                                      true
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count] == 7)
+                  |                           |                 |                  | |  |
+                  |                           |                 "hexagonal"        7 |  7
+                  |                           |                                      true
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
         )
@@ -1546,7 +1546,7 @@ final class PowerAssertTests: XCTestCase {
         "triangular": [1, 3, 6, 10, 15, 21, 28],
         "hexagonal": [1, 6, 15, 28, 45, 66, 91]
       ]
-      #powerAssert(
+      #expect(
         interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64,
         verbose: true
       )
@@ -1557,73 +1557,73 @@ final class PowerAssertTests: XCTestCase {
         XCTAssertTrue(
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           Swift.KeyPath<Swift.Dictionary<Swift.String, Swift.Array<Swift.Int>>, Swift.Int>
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
         )
@@ -1631,73 +1631,73 @@ final class PowerAssertTests: XCTestCase {
         XCTAssertTrue(
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
-                       ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
+                  ["prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15], "triangular": [1, 3, 6, 10, 15, 21, 28]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
-                       ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
+                  ["hexagonal": [1, 6, 15, 28, 45, 66, 91], "triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "prime": [2, 3, 5, 7, 11, 13, 15], "hexagonal": [1, 6, 15, 28, 45, 66, 91]]
 
           """#
           ||
           output ==
           #"""
-          #powerAssert(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
-                       |                           |                 |                           | |  |
-                       |                           |                 "hexagonal"                 | |  64
-                       |                           |                                             | true
-                       |                           |                                             64
-                       |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
-                       ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
+          #expect(interestingNumbers[keyPath: \[String: [Int]].["hexagonal"]!.count.bitWidth] == 64)
+                  |                           |                 |                           | |  |
+                  |                           |                 "hexagonal"                 | |  64
+                  |                           |                                             | true
+                  |                           |                                             64
+                  |                           \Dictionary<String, Array<Int>>.<computed 0x00000001a128b19c (Optional<Array<Int>>)>!.count.bitWidth
+                  ["triangular": [1, 3, 6, 10, 15, 21, 28], "hexagonal": [1, 6, 15, 28, 45, 66, 91], "prime": [2, 3, 5, 7, 11, 13, 15]]
 
           """#
         )
@@ -1724,22 +1724,22 @@ final class PowerAssertTests: XCTestCase {
 
   func testPostfixSelfExpression() {
     captureConsoleOutput {
-      #powerAssert(String.self != Int.self && "string".self == "string", verbose: true)
+      #expect(String.self != Int.self && "string".self == "string", verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(String.self != Int.self && "string".self == "string")
-                     |      |    |  |   |    |  |        |    |  |
-                     |      |    |  |   |    |  "string" |    |  "string"
-                     |      |    |  |   |    true        |    true
-                     |      |    |  |   |                "string"
-                     |      |    |  |   Optional(Swift.Int)
-                     |      |    |  Optional(Swift.Int)
-                     |      |    true
-                     |      Optional(Swift.String)
-                     Optional(Swift.String)
+        #expect(String.self != Int.self && "string".self == "string")
+                |      |    |  |   |    |  |        |    |  |
+                |      |    |  |   |    |  "string" |    |  "string"
+                |      |    |  |   |    true        |    true
+                |      |    |  |   |                "string"
+                |      |    |  |   Optional(Swift.Int)
+                |      |    |  Optional(Swift.Int)
+                |      |    true
+                |      Optional(Swift.String)
+                Optional(Swift.String)
 
         """
       )
@@ -1973,59 +1973,58 @@ final class PowerAssertTests: XCTestCase {
       let date = dc.date!
 
       let kanjiName = "岸川克己"
-      let emojiName = "😇岸川克己🇯🇵"
 
       let tuple = (name: kanjiName, age: 37, birthday: date)
 
-      #powerAssert(tuple == (name: kanjiName, age: 37, birthday: date), verbose: true)
-      #powerAssert(tuple == (kanjiName, 37, date), verbose: true)
-      #powerAssert(tuple.name == (kanjiName, 37, date).0 || tuple.age == (kanjiName, 37, date).1, verbose: true)
-      #powerAssert(tuple.name == (kanjiName, 37, date).0 && tuple.age == (kanjiName, 37, date).1, verbose: true)
+      #expect(tuple == (name: kanjiName, age: 37, birthday: date), verbose: true)
+      #expect(tuple == (kanjiName, 37, date), verbose: true)
+      #expect(tuple.name == (kanjiName, 37, date).0 || tuple.age == (kanjiName, 37, date).1, verbose: true)
+      #expect(tuple.name == (kanjiName, 37, date).0 && tuple.age == (kanjiName, 37, date).1, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(tuple == (name: kanjiName, age: 37, birthday: date))
-                     |     |  |      |               |             |
-                     |     |  |      |               37            1980-10-27 15:00:00 +0000
-                     |     |  |      "岸川克己"
-                     |     |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     true
-                     ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple == (kanjiName, 37, date))
-                     |     |  ||          |   |
-                     |     |  ||          37  1980-10-27 15:00:00 +0000
-                     |     |  |"岸川克己"
-                     |     |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     true
-                     ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple.name == (kanjiName, 37, date).0 || tuple.age == (kanjiName, 37, date).1)
-                     |     |    |  ||          |   |     | |
-                     |     |    |  ||          37  |     | true
-                     |     |    |  ||              |     "岸川克己"
-                     |     |    |  ||              1980-10-27 15:00:00 +0000
-                     |     |    |  |"岸川克己"
-                     |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    true
-                     |     "岸川克己"
-                     (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple.name == (kanjiName, 37, date).0 && tuple.age == (kanjiName, 37, date).1)
-                     |     |    |  ||          |   |     | |  |     |   |  ||          |   |     |
-                     |     |    |  ||          37  |     | |  |     37  |  ||          37  |     37
-                     |     |    |  ||              |     | |  |         |  ||              1980-10-27 15:00:00 +0000
-                     |     |    |  ||              |     | |  |         |  |"岸川克己"
-                     |     |    |  ||              |     | |  |         |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    |  ||              |     | |  |         true
-                     |     |    |  ||              |     | |  (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
-                     |     |    |  ||              |     | true
-                     |     |    |  ||              |     "岸川克己"
-                     |     |    |  ||              1980-10-27 15:00:00 +0000
-                     |     |    |  |"岸川克己"
-                     |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    true
-                     |     "岸川克己"
-                     (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+        #expect(tuple == (name: kanjiName, age: 37, birthday: date))
+                |     |  |      |               |             |
+                |     |  |      |               37            1980-10-27 15:00:00 +0000
+                |     |  |      "岸川克己"
+                |     |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     true
+                ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+        #expect(tuple == (kanjiName, 37, date))
+                |     |  ||          |   |
+                |     |  ||          37  1980-10-27 15:00:00 +0000
+                |     |  |"岸川克己"
+                |     |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     true
+                ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+        #expect(tuple.name == (kanjiName, 37, date).0 || tuple.age == (kanjiName, 37, date).1)
+                |     |    |  ||          |   |     | |
+                |     |    |  ||          37  |     | true
+                |     |    |  ||              |     "岸川克己"
+                |     |    |  ||              1980-10-27 15:00:00 +0000
+                |     |    |  |"岸川克己"
+                |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     |    true
+                |     "岸川克己"
+                (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+        #expect(tuple.name == (kanjiName, 37, date).0 && tuple.age == (kanjiName, 37, date).1)
+                |     |    |  ||          |   |     | |  |     |   |  ||          |   |     |
+                |     |    |  ||          37  |     | |  |     37  |  ||          37  |     37
+                |     |    |  ||              |     | |  |         |  ||              1980-10-27 15:00:00 +0000
+                |     |    |  ||              |     | |  |         |  |"岸川克己"
+                |     |    |  ||              |     | |  |         |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     |    |  ||              |     | |  |         true
+                |     |    |  ||              |     | |  (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+                |     |    |  ||              |     | true
+                |     |    |  ||              |     "岸川克己"
+                |     |    |  ||              1980-10-27 15:00:00 +0000
+                |     |    |  |"岸川克己"
+                |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     |    true
+                |     "岸川克己"
+                (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
 
         """
       )
@@ -2048,67 +2047,67 @@ final class PowerAssertTests: XCTestCase {
 
       let tuple = (name: kanjiName, age: 37, birthday: date)
 
-      #powerAssert(tuple.name != (emojiName, 37, date).0 || tuple.age == (kanjiName, 37, date).1, verbose: true)
-      #powerAssert(tuple.name == (kanjiName, 37, date).0 || tuple.age == (emojiName, 37, date).1, verbose: true)
-      #powerAssert(tuple.name != (emojiName, 37, date).0 && tuple.age == (kanjiName, 37, date).1, verbose: true)
-      #powerAssert(tuple.name == (kanjiName, 37, date).0 && tuple.age == (emojiName, 37, date).1, verbose: true)
+      #expect(tuple.name != (emojiName, 37, date).0 || tuple.age == (kanjiName, 37, date).1, verbose: true)
+      #expect(tuple.name == (kanjiName, 37, date).0 || tuple.age == (emojiName, 37, date).1, verbose: true)
+      #expect(tuple.name != (emojiName, 37, date).0 && tuple.age == (kanjiName, 37, date).1, verbose: true)
+      #expect(tuple.name == (kanjiName, 37, date).0 && tuple.age == (emojiName, 37, date).1, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(tuple.name != (emojiName, 37, date).0 || tuple.age == (kanjiName, 37, date).1)
-                     |     |    |  ||          |   |     | |
-                     |     |    |  ||          37  |     | true
-                     |     |    |  ||              |     "😇岸川克己🇯🇵"
-                     |     |    |  ||              1980-10-27 15:00:00 +0000
-                     |     |    |  |"😇岸川克己🇯🇵"
-                     |     |    |  ("😇岸川克己🇯🇵", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    true
-                     |     "岸川克己"
-                     (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple.name == (kanjiName, 37, date).0 || tuple.age == (emojiName, 37, date).1)
-                     |     |    |  ||          |   |     | |
-                     |     |    |  ||          37  |     | true
-                     |     |    |  ||              |     "岸川克己"
-                     |     |    |  ||              1980-10-27 15:00:00 +0000
-                     |     |    |  |"岸川克己"
-                     |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    true
-                     |     "岸川克己"
-                     (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple.name != (emojiName, 37, date).0 && tuple.age == (kanjiName, 37, date).1)
-                     |     |    |  ||          |   |     | |  |     |   |  ||          |   |     |
-                     |     |    |  ||          37  |     | |  |     37  |  ||          37  |     37
-                     |     |    |  ||              |     | |  |         |  ||              1980-10-27 15:00:00 +0000
-                     |     |    |  ||              |     | |  |         |  |"岸川克己"
-                     |     |    |  ||              |     | |  |         |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    |  ||              |     | |  |         true
-                     |     |    |  ||              |     | |  (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
-                     |     |    |  ||              |     | true
-                     |     |    |  ||              |     "😇岸川克己🇯🇵"
-                     |     |    |  ||              1980-10-27 15:00:00 +0000
-                     |     |    |  |"😇岸川克己🇯🇵"
-                     |     |    |  ("😇岸川克己🇯🇵", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    true
-                     |     "岸川克己"
-                     (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple.name == (kanjiName, 37, date).0 && tuple.age == (emojiName, 37, date).1)
-                     |     |    |  ||          |   |     | |  |     |   |  ||          |   |     |
-                     |     |    |  ||          37  |     | |  |     37  |  ||          37  |     37
-                     |     |    |  ||              |     | |  |         |  ||              1980-10-27 15:00:00 +0000
-                     |     |    |  ||              |     | |  |         |  |"😇岸川克己🇯🇵"
-                     |     |    |  ||              |     | |  |         |  ("😇岸川克己🇯🇵", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    |  ||              |     | |  |         true
-                     |     |    |  ||              |     | |  (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
-                     |     |    |  ||              |     | true
-                     |     |    |  ||              |     "岸川克己"
-                     |     |    |  ||              1980-10-27 15:00:00 +0000
-                     |     |    |  |"岸川克己"
-                     |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    true
-                     |     "岸川克己"
-                     (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+        #expect(tuple.name != (emojiName, 37, date).0 || tuple.age == (kanjiName, 37, date).1)
+                |     |    |  ||          |   |     | |
+                |     |    |  ||          37  |     | true
+                |     |    |  ||              |     "😇岸川克己🇯🇵"
+                |     |    |  ||              1980-10-27 15:00:00 +0000
+                |     |    |  |"😇岸川克己🇯🇵"
+                |     |    |  ("😇岸川克己🇯🇵", 37, 1980-10-27 15:00:00 +0000)
+                |     |    true
+                |     "岸川克己"
+                (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+        #expect(tuple.name == (kanjiName, 37, date).0 || tuple.age == (emojiName, 37, date).1)
+                |     |    |  ||          |   |     | |
+                |     |    |  ||          37  |     | true
+                |     |    |  ||              |     "岸川克己"
+                |     |    |  ||              1980-10-27 15:00:00 +0000
+                |     |    |  |"岸川克己"
+                |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     |    true
+                |     "岸川克己"
+                (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+        #expect(tuple.name != (emojiName, 37, date).0 && tuple.age == (kanjiName, 37, date).1)
+                |     |    |  ||          |   |     | |  |     |   |  ||          |   |     |
+                |     |    |  ||          37  |     | |  |     37  |  ||          37  |     37
+                |     |    |  ||              |     | |  |         |  ||              1980-10-27 15:00:00 +0000
+                |     |    |  ||              |     | |  |         |  |"岸川克己"
+                |     |    |  ||              |     | |  |         |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     |    |  ||              |     | |  |         true
+                |     |    |  ||              |     | |  (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+                |     |    |  ||              |     | true
+                |     |    |  ||              |     "😇岸川克己🇯🇵"
+                |     |    |  ||              1980-10-27 15:00:00 +0000
+                |     |    |  |"😇岸川克己🇯🇵"
+                |     |    |  ("😇岸川克己🇯🇵", 37, 1980-10-27 15:00:00 +0000)
+                |     |    true
+                |     "岸川克己"
+                (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+        #expect(tuple.name == (kanjiName, 37, date).0 && tuple.age == (emojiName, 37, date).1)
+                |     |    |  ||          |   |     | |  |     |   |  ||          |   |     |
+                |     |    |  ||          37  |     | |  |     37  |  ||          37  |     37
+                |     |    |  ||              |     | |  |         |  ||              1980-10-27 15:00:00 +0000
+                |     |    |  ||              |     | |  |         |  |"😇岸川克己🇯🇵"
+                |     |    |  ||              |     | |  |         |  ("😇岸川克己🇯🇵", 37, 1980-10-27 15:00:00 +0000)
+                |     |    |  ||              |     | |  |         true
+                |     |    |  ||              |     | |  (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+                |     |    |  ||              |     | true
+                |     |    |  ||              |     "岸川克己"
+                |     |    |  ||              1980-10-27 15:00:00 +0000
+                |     |    |  |"岸川克己"
+                |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     |    true
+                |     "岸川克己"
+                (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
 
         """
       )
@@ -2131,55 +2130,55 @@ final class PowerAssertTests: XCTestCase {
 
       let tuple = (name: kanjiName, age: 37, birthday: date)
 
-      #powerAssert(tuple == (name: "岸川克己", age: 37, birthday: date), verbose: true)
-      #powerAssert(tuple == ("岸川克己", 37, date), verbose: true)
-      #powerAssert(tuple.name == ("岸川克己", 37, date).0 || tuple.age == ("岸川克己", 37, date).1, verbose: true)
-      #powerAssert(tuple.name == ("岸川克己", 37, date).0 && tuple.age == ("岸川克己", 37, date).1, verbose: true)
+      #expect(tuple == (name: "岸川克己", age: 37, birthday: date), verbose: true)
+      #expect(tuple == ("岸川克己", 37, date), verbose: true)
+      #expect(tuple.name == ("岸川克己", 37, date).0 || tuple.age == ("岸川克己", 37, date).1, verbose: true)
+      #expect(tuple.name == ("岸川克己", 37, date).0 && tuple.age == ("岸川克己", 37, date).1, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(tuple == (name: "岸川克己", age: 37, birthday: date))
-                     |     |  |      |                    |             |
-                     |     |  |      |                    37            1980-10-27 15:00:00 +0000
-                     |     |  |      "岸川克己"
-                     |     |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     true
-                     ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple == ("岸川克己", 37, date))
-                     |     |  ||               |   |
-                     |     |  ||               37  1980-10-27 15:00:00 +0000
-                     |     |  |"岸川克己"
-                     |     |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     true
-                     ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple.name == ("岸川克己", 37, date).0 || tuple.age == ("岸川克己", 37, date).1)
-                     |     |    |  ||               |   |     | |
-                     |     |    |  ||               37  |     | true
-                     |     |    |  ||                   |     "岸川克己"
-                     |     |    |  ||                   1980-10-27 15:00:00 +0000
-                     |     |    |  |"岸川克己"
-                     |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    true
-                     |     "岸川克己"
-                     (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
-        #powerAssert(tuple.name == ("岸川克己", 37, date).0 && tuple.age == ("岸川克己", 37, date).1)
-                     |     |    |  ||               |   |     | |  |     |   |  ||               |   |     |
-                     |     |    |  ||               37  |     | |  |     37  |  ||               37  |     37
-                     |     |    |  ||                   |     | |  |         |  ||                   1980-10-27 15:00:00 +0000
-                     |     |    |  ||                   |     | |  |         |  |"岸川克己"
-                     |     |    |  ||                   |     | |  |         |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    |  ||                   |     | |  |         true
-                     |     |    |  ||                   |     | |  (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
-                     |     |    |  ||                   |     | true
-                     |     |    |  ||                   |     "岸川克己"
-                     |     |    |  ||                   1980-10-27 15:00:00 +0000
-                     |     |    |  |"岸川克己"
-                     |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
-                     |     |    true
-                     |     "岸川克己"
-                     (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+        #expect(tuple == (name: "岸川克己", age: 37, birthday: date))
+                |     |  |      |                    |             |
+                |     |  |      |                    37            1980-10-27 15:00:00 +0000
+                |     |  |      "岸川克己"
+                |     |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     true
+                ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+        #expect(tuple == ("岸川克己", 37, date))
+                |     |  ||               |   |
+                |     |  ||               37  1980-10-27 15:00:00 +0000
+                |     |  |"岸川克己"
+                |     |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     true
+                ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+        #expect(tuple.name == ("岸川克己", 37, date).0 || tuple.age == ("岸川克己", 37, date).1)
+                |     |    |  ||               |   |     | |
+                |     |    |  ||               37  |     | true
+                |     |    |  ||                   |     "岸川克己"
+                |     |    |  ||                   1980-10-27 15:00:00 +0000
+                |     |    |  |"岸川克己"
+                |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     |    true
+                |     "岸川克己"
+                (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+        #expect(tuple.name == ("岸川克己", 37, date).0 && tuple.age == ("岸川克己", 37, date).1)
+                |     |    |  ||               |   |     | |  |     |   |  ||               |   |     |
+                |     |    |  ||               37  |     | |  |     37  |  ||               37  |     37
+                |     |    |  ||                   |     | |  |         |  ||                   1980-10-27 15:00:00 +0000
+                |     |    |  ||                   |     | |  |         |  |"岸川克己"
+                |     |    |  ||                   |     | |  |         |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     |    |  ||                   |     | |  |         true
+                |     |    |  ||                   |     | |  (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
+                |     |    |  ||                   |     | true
+                |     |    |  ||                   |     "岸川克己"
+                |     |    |  ||                   1980-10-27 15:00:00 +0000
+                |     |    |  |"岸川克己"
+                |     |    |  ("岸川克己", 37, 1980-10-27 15:00:00 +0000)
+                |     |    true
+                |     "岸川克己"
+                (name: "岸川克己", age: 37, birthday: 1980-10-27 15:00:00 +0000)
 
         """
       )
@@ -2272,20 +2271,20 @@ final class PowerAssertTests: XCTestCase {
     captureConsoleOutput {
       let bar = Bar(foo: Foo(val: 2), val: 3)
 #if swift(>=3.2)
-      #powerAssert(bar.val != bar.foo.val, verbose: true)
+      #expect(bar.val != bar.foo.val, verbose: true)
 #endif
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(bar.val != bar.foo.val)
-                     |   |   |  |   |   |
-                     |   3   |  |   |   2
-                     |       |  |   Foo(val: 2)
-                     |       |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
-                     |       true
-                     Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+        #expect(bar.val != bar.foo.val)
+                |   |   |  |   |   |
+                |   3   |  |   |   2
+                |       |  |   Foo(val: 2)
+                |       |  Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
+                |       true
+                Bar(foo: PowerAssertTests.Foo(val: 2), val: 3)
 
         """
       )
@@ -2384,7 +2383,7 @@ final class PowerAssertTests: XCTestCase {
       let three = 3
 
       let array = [one, two, three]
-      #powerAssert(
+      #expect(
         array.description.hasPrefix("[") != false && array.description.hasPrefix("Hello") != true,
         "message",
         verbose: true
@@ -2394,11 +2393,11 @@ final class PowerAssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         """
-        #powerAssert(array.description.hasPrefix("[") != false && array.description.hasPrefix("Hello") != true)
-                     |     |           |         |    |  |     |  |     |           |         |        |  |
-                     |     "[1, 2, 3]" true      "["  |  false |  |     "[1, 2, 3]" false     "Hello"  |  true
-                     [1, 2, 3]                        true     |  [1, 2, 3]                            true
-                                                               true
+        #expect(array.description.hasPrefix("[") != false && array.description.hasPrefix("Hello") != true)
+                |     |           |         |    |  |     |  |     |           |         |        |  |
+                |     "[1, 2, 3]" true      "["  |  false |  |     "[1, 2, 3]" false     "Hello"  |  true
+                [1, 2, 3]                        true     |  [1, 2, 3]                            true
+                                                          true
 
         """
       )
@@ -2408,7 +2407,7 @@ final class PowerAssertTests: XCTestCase {
   func testStringContainsNewlines() {
     captureConsoleOutput {
       let loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-      #powerAssert(
+      #expect(
         loremIpsum != "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit,",
         verbose: true
       )
@@ -2417,11 +2416,11 @@ final class PowerAssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         #"""
-        #powerAssert(loremIpsum != "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit,")
-                     |          |  |
-                     |          |  "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit,"
-                     |          true
-                     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+        #expect(loremIpsum != "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit,")
+                |          |  |
+                |          |  "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit,"
+                |          true
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
 
         """#
       )
@@ -2431,37 +2430,37 @@ final class PowerAssertTests: XCTestCase {
   func testStringContainsEscapeSequences1() {
     captureConsoleOutput {
       let lyric1 = "Feet, don't fail me now."
-      #powerAssert(lyric1 == "Feet, don't fail me now.", verbose: true)
-      #powerAssert(lyric1 == "Feet, don\'t fail me now.", verbose: true)
+      #expect(lyric1 == "Feet, don't fail me now.", verbose: true)
+      #expect(lyric1 == "Feet, don\'t fail me now.", verbose: true)
 
       let lyric2 = "Feet, don\'t fail me now."
-      #powerAssert(lyric2 == "Feet, don't fail me now.", verbose: true)
-      #powerAssert(lyric2 == "Feet, don\'t fail me now.", verbose: true)
+      #expect(lyric2 == "Feet, don't fail me now.", verbose: true)
+      #expect(lyric2 == "Feet, don\'t fail me now.", verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         #"""
-        #powerAssert(lyric1 == "Feet, don't fail me now.")
-                     |      |  |
-                     |      |  "Feet, don't fail me now."
-                     |      true
-                     "Feet, don't fail me now."
-        #powerAssert(lyric1 == "Feet, don\'t fail me now.")
-                     |      |  |
-                     |      |  "Feet, don't fail me now."
-                     |      true
-                     "Feet, don't fail me now."
-        #powerAssert(lyric2 == "Feet, don't fail me now.")
-                     |      |  |
-                     |      |  "Feet, don't fail me now."
-                     |      true
-                     "Feet, don't fail me now."
-        #powerAssert(lyric2 == "Feet, don\'t fail me now.")
-                     |      |  |
-                     |      |  "Feet, don't fail me now."
-                     |      true
-                     "Feet, don't fail me now."
+        #expect(lyric1 == "Feet, don't fail me now.")
+                |      |  |
+                |      |  "Feet, don't fail me now."
+                |      true
+                "Feet, don't fail me now."
+        #expect(lyric1 == "Feet, don\'t fail me now.")
+                |      |  |
+                |      |  "Feet, don't fail me now."
+                |      true
+                "Feet, don't fail me now."
+        #expect(lyric2 == "Feet, don't fail me now.")
+                |      |  |
+                |      |  "Feet, don't fail me now."
+                |      true
+                "Feet, don't fail me now."
+        #expect(lyric2 == "Feet, don\'t fail me now.")
+                |      |  |
+                |      |  "Feet, don't fail me now."
+                |      true
+                "Feet, don't fail me now."
 
         """#
       )
@@ -2471,37 +2470,37 @@ final class PowerAssertTests: XCTestCase {
   func testStringContainsEscapeSequences2() {
     captureConsoleOutput {
       let nestedQuote1 = "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
-      #powerAssert(nestedQuote1 == "My mother said, \"The baby started talking today. The baby said, 'Mama.'\"", verbose: true)
-      #powerAssert(nestedQuote1 == "My mother said, \"The baby started talking today. The baby said, \'Mama.\'\"", verbose: true)
+      #expect(nestedQuote1 == "My mother said, \"The baby started talking today. The baby said, 'Mama.'\"", verbose: true)
+      #expect(nestedQuote1 == "My mother said, \"The baby started talking today. The baby said, \'Mama.\'\"", verbose: true)
 
       let nestedQuote2 = "My mother said, \"The baby started talking today. The baby said, \'Mama.\'\""
-      #powerAssert(nestedQuote2 == "My mother said, \"The baby started talking today. The baby said, 'Mama.'\"", verbose: true)
-      #powerAssert(nestedQuote2 == "My mother said, \"The baby started talking today. The baby said, \'Mama.\'\"", verbose: true)
+      #expect(nestedQuote2 == "My mother said, \"The baby started talking today. The baby said, 'Mama.'\"", verbose: true)
+      #expect(nestedQuote2 == "My mother said, \"The baby started talking today. The baby said, \'Mama.\'\"", verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         #"""
-        #powerAssert(nestedQuote1 == "My mother said, \"The baby started talking today. The baby said, 'Mama.'\"")
-                     |            |  |
-                     |            |  "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
-                     |            true
-                     "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
-        #powerAssert(nestedQuote1 == "My mother said, \"The baby started talking today. The baby said, \'Mama.\'\"")
-                     |            |  |
-                     |            |  "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
-                     |            true
-                     "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
-        #powerAssert(nestedQuote2 == "My mother said, \"The baby started talking today. The baby said, 'Mama.'\"")
-                     |            |  |
-                     |            |  "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
-                     |            true
-                     "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
-        #powerAssert(nestedQuote2 == "My mother said, \"The baby started talking today. The baby said, \'Mama.\'\"")
-                     |            |  |
-                     |            |  "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
-                     |            true
-                     "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
+        #expect(nestedQuote1 == "My mother said, \"The baby started talking today. The baby said, 'Mama.'\"")
+                |            |  |
+                |            |  "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
+                |            true
+                "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
+        #expect(nestedQuote1 == "My mother said, \"The baby started talking today. The baby said, \'Mama.\'\"")
+                |            |  |
+                |            |  "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
+                |            true
+                "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
+        #expect(nestedQuote2 == "My mother said, \"The baby started talking today. The baby said, 'Mama.'\"")
+                |            |  |
+                |            |  "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
+                |            true
+                "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
+        #expect(nestedQuote2 == "My mother said, \"The baby started talking today. The baby said, \'Mama.\'\"")
+                |            |  |
+                |            |  "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
+                |            true
+                "My mother said, \"The baby started talking today. The baby said, 'Mama.'\""
 
         """#
       )
@@ -2511,17 +2510,17 @@ final class PowerAssertTests: XCTestCase {
   func testStringContainsEscapeSequences3() {
     captureConsoleOutput {
       let helpText = "OPTIONS:\n  --build-path\t\tSpecify build/cache directory [default: ./.build]"
-      #powerAssert(helpText == "OPTIONS:\n  --build-path\t\tSpecify build/cache directory [default: ./.build]", verbose: true)
+      #expect(helpText == "OPTIONS:\n  --build-path\t\tSpecify build/cache directory [default: ./.build]", verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         #"""
-        #powerAssert(helpText == "OPTIONS:\n  --build-path\t\tSpecify build/cache directory [default: ./.build]")
-                     |        |  |
-                     |        |  "OPTIONS:\n  --build-path\t\tSpecify build/cache directory [default: ./.build]"
-                     |        true
-                     "OPTIONS:\n  --build-path\t\tSpecify build/cache directory [default: ./.build]"
+        #expect(helpText == "OPTIONS:\n  --build-path\t\tSpecify build/cache directory [default: ./.build]")
+                |        |  |
+                |        |  "OPTIONS:\n  --build-path\t\tSpecify build/cache directory [default: ./.build]"
+                |        true
+                "OPTIONS:\n  --build-path\t\tSpecify build/cache directory [default: ./.build]"
 
         """#
       )
@@ -2531,41 +2530,41 @@ final class PowerAssertTests: XCTestCase {
   func testStringContainsEscapeSequences4() {
     captureConsoleOutput {
       let nullCharacter = "Null character\0Null character"
-      #powerAssert(nullCharacter == "Null character\0Null character", verbose: true)
+      #expect(nullCharacter == "Null character\0Null character", verbose: true)
 
       let lineFeed = "Line feed\nLine feed"
-      #powerAssert(lineFeed == "Line feed\nLine feed", verbose: true)
+      #expect(lineFeed == "Line feed\nLine feed", verbose: true)
 
       let carriageReturn = "Carriage Return\rCarriage Return"
-      #powerAssert(carriageReturn == "Carriage Return\rCarriage Return", verbose: true)
+      #expect(carriageReturn == "Carriage Return\rCarriage Return", verbose: true)
 
       let backslash = "Backslash\\Backslash"
-      #powerAssert(backslash == "Backslash\\Backslash", verbose: true)
+      #expect(backslash == "Backslash\\Backslash", verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         #"""
-        #powerAssert(nullCharacter == "Null character\0Null character")
-                     |             |  |
-                     |             |  "Null character\0Null character"
-                     |             true
-                     "Null character\0Null character"
-        #powerAssert(lineFeed == "Line feed\nLine feed")
-                     |        |  |
-                     |        |  "Line feed\nLine feed"
-                     |        true
-                     "Line feed\nLine feed"
-        #powerAssert(carriageReturn == "Carriage Return\rCarriage Return")
-                     |              |  |
-                     |              |  "Carriage Return\rCarriage Return"
-                     |              true
-                     "Carriage Return\rCarriage Return"
-        #powerAssert(backslash == "Backslash\\Backslash")
-                     |         |  |
-                     |         |  "Backslash\Backslash"
-                     |         true
-                     "Backslash\Backslash"
+        #expect(nullCharacter == "Null character\0Null character")
+                |             |  |
+                |             |  "Null character\0Null character"
+                |             true
+                "Null character\0Null character"
+        #expect(lineFeed == "Line feed\nLine feed")
+                |        |  |
+                |        |  "Line feed\nLine feed"
+                |        true
+                "Line feed\nLine feed"
+        #expect(carriageReturn == "Carriage Return\rCarriage Return")
+                |              |  |
+                |              |  "Carriage Return\rCarriage Return"
+                |              true
+                "Carriage Return\rCarriage Return"
+        #expect(backslash == "Backslash\\Backslash")
+                |         |  |
+                |         |  "Backslash\Backslash"
+                |         true
+                "Backslash\Backslash"
 
         """#
       )
@@ -2578,34 +2577,34 @@ final class PowerAssertTests: XCTestCase {
       let dollarSign = "\u{24}"        // $,  Unicode scalar U+0024
       let blackHeart = "\u{2665}"      // ♥,  Unicode scalar U+2665
       let sparklingHeart = "\u{1F496}" // 💖, Unicode scalar U+1F496
-      #powerAssert(wiseWords == "\"Imagination is more important than knowledge\" - Einstein", verbose: true)
-      #powerAssert(dollarSign == "\u{24}", verbose: true)
-      #powerAssert(blackHeart == "\u{2665}", verbose: true)
-      #powerAssert(sparklingHeart == "\u{1F496}", verbose: true)
+      #expect(wiseWords == "\"Imagination is more important than knowledge\" - Einstein", verbose: true)
+      #expect(dollarSign == "\u{24}", verbose: true)
+      #expect(blackHeart == "\u{2665}", verbose: true)
+      #expect(sparklingHeart == "\u{1F496}", verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         #"""
-        #powerAssert(wiseWords == "\"Imagination is more important than knowledge\" - Einstein")
-                     |         |  |
-                     |         |  "\"Imagination is more important than knowledge\" - Einstein"
-                     |         true
-                     "\"Imagination is more important than knowledge\" - Einstein"
-        #powerAssert(dollarSign == "\u{24}")
-                     |          |  |
-                     "$"        |  "$"
-                                true
-        #powerAssert(blackHeart == "\u{2665}")
-                     |          |  |
-                     |          |  "♥"
-                     |          true
-                     "♥"
-        #powerAssert(sparklingHeart == "\u{1F496}")
-                     |              |  |
-                     |              |  "💖"
-                     |              true
-                     "💖"
+        #expect(wiseWords == "\"Imagination is more important than knowledge\" - Einstein")
+                |         |  |
+                |         |  "\"Imagination is more important than knowledge\" - Einstein"
+                |         true
+                "\"Imagination is more important than knowledge\" - Einstein"
+        #expect(dollarSign == "\u{24}")
+                |          |  |
+                "$"        |  "$"
+                           true
+        #expect(blackHeart == "\u{2665}")
+                |          |  |
+                |          |  "♥"
+                |          true
+                "♥"
+        #expect(sparklingHeart == "\u{1F496}")
+                |              |  |
+                |              |  "💖"
+                |              true
+                "💖"
 
         """#
       )
@@ -2654,41 +2653,41 @@ final class PowerAssertTests: XCTestCase {
     captureConsoleOutput {
       let number1 = 100.0
       let number2 = 200.0
-      #powerAssert(number1 × number2 == 20000.0, verbose: true) // FIXME: Print the value of the expression
-      #powerAssert(√number2 == 14.142135623730951, verbose: true)
-      #powerAssert(√√number2 != 200.0, verbose: true)
-      #powerAssert(3.760603093086394 == √√number2, verbose: true)
-      #powerAssert(√number2 != √√number2, verbose: true)
+      #expect(number1 × number2 == 20000.0, verbose: true) // FIXME: Print the value of the expression
+      #expect(√number2 == 14.142135623730951, verbose: true)
+      #expect(√√number2 != 200.0, verbose: true)
+      #expect(3.760603093086394 == √√number2, verbose: true)
+      #expect(√number2 != √√number2, verbose: true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(number1 × number2 == 20000.0)
-                     |       |  |          |
-                     100.0   |  200.0      20000.0
-                             true
-        #powerAssert(√number2 == 14.142135623730951)
-                     |  |       |  |
-                     |  200.0   |  14.142135623730951
-                     |          true
-                     14.142135623730951
-        #powerAssert(√√number2 != 200.0)
-                     |     |       |  |
-                     |     200.0   |  200.0
-                     |             true
-                     3.760603093086394
-        #powerAssert(3.760603093086394 == √√number2)
-                     |                 |  |     |
-                     3.760603093086394 |  |     200.0
-                                       |  3.760603093086394
-                                       true
-        #powerAssert(√number2 != √√number2)
-                     |  |       |  |     |
-                     |  200.0   |  |     200.0
-                     |          |  3.760603093086394
-                     |          true
-                     14.142135623730951
+        #expect(number1 × number2 == 20000.0)
+                |       |  |          |
+                100.0   |  200.0      20000.0
+                        true
+        #expect(√number2 == 14.142135623730951)
+                |  |       |  |
+                |  200.0   |  14.142135623730951
+                |          true
+                14.142135623730951
+        #expect(√√number2 != 200.0)
+                |     |       |  |
+                |     200.0   |  200.0
+                |             true
+                3.760603093086394
+        #expect(3.760603093086394 == √√number2)
+                |                 |  |     |
+                3.760603093086394 |  |     200.0
+                                  |  3.760603093086394
+                                  true
+        #expect(√number2 != √√number2)
+                |  |       |  |     |
+                |  200.0   |  |     200.0
+                |          |  3.760603093086394
+                |          true
+                14.142135623730951
 
         """
       )
@@ -2702,31 +2701,31 @@ final class PowerAssertTests: XCTestCase {
       let i2=1
       let d1=4.0
       let d2=6.0
-      #powerAssert(i2==1,verbose:true)
-      #powerAssert(b1==false&&i1<i2||false==b1&&i2==1,verbose:true)
-      #powerAssert(b1==false&&i1<i2||false==b1&&i2==1||d1×d2==24.0,verbose:true)
+      #expect(i2==1,verbose:true)
+      #expect(b1==false&&i1<i2||false==b1&&i2==1,verbose:true)
+      #expect(b1==false&&i1<i2||false==b1&&i2==1||d1×d2==24.0,verbose:true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(i2==1)
-                     | | |
-                     1 | 1
-                       true
-        #powerAssert(b1==false&&i1<i2||false==b1&&i2==1)
-                     | | |    | | || |
-                     | | |    | 0 |1 true
-                     | | |    |   true
-                     | | |    true
-                     | | false
-                     | true
-                     false
-        #powerAssert(b1==false&&i1<i2||false==b1&&i2==1||d1×d2==24.0)
-                     | | |      |  |
-                     | | false  0  1
-                     | true
-                     false
+        #expect(i2==1)
+                | | |
+                1 | 1
+                  true
+        #expect(b1==false&&i1<i2||false==b1&&i2==1)
+                | | |    | | || |
+                | | |    | 0 |1 true
+                | | |    |   true
+                | | |    true
+                | | false
+                | true
+                false
+        #expect(b1==false&&i1<i2||false==b1&&i2==1||d1×d2==24.0)
+                | | |      |  |
+                | | false  0  1
+                | true
+                false
 
         """
       )
@@ -2740,37 +2739,37 @@ final class PowerAssertTests: XCTestCase {
       let i2=1
       let d1=4.0
       let d2=6.0
-      #powerAssert(i2==1,verbose:true)
-      #powerAssert(b1==false&&i1<i2&&false==b1&&i2==1,verbose:true)
-      #powerAssert(b1==false&&i1<i2&&false==b1&&i2==1||d1×d2==24.0,verbose:true)
+      #expect(i2==1,verbose:true)
+      #expect(b1==false&&i1<i2&&false==b1&&i2==1,verbose:true)
+      #expect(b1==false&&i1<i2&&false==b1&&i2==1||d1×d2==24.0,verbose:true)
     } completion: { (output) in
       print(output)
       XCTAssertEqual(
         output,
         """
-        #powerAssert(i2==1)
-                     | | |
-                     1 | 1
-                       true
-        #powerAssert(b1==false&&i1<i2&&false==b1&&i2==1)
-                     | | |    | | || | |    | | | | | |
-                     | | |    | 0 |1 | |    | | | 1 | 1
-                     | | |    |   |  | |    | | |   true
-                     | | |    |   |  | |    | | true
-                     | | |    |   |  | |    | false
-                     | | |    |   |  | |    true
-                     | | |    |   |  | false
-                     | | |    |   |  true
-                     | | |    |   true
-                     | | |    true
-                     | | false
-                     | true
-                     false
-        #powerAssert(b1==false&&i1<i2&&false==b1&&i2==1||d1×d2==24.0)
-                     | | |      |  |   |      |   |   |
-                     | | false  0  1   false  |   1   1
-                     | true                   false
-                     false
+        #expect(i2==1)
+                | | |
+                1 | 1
+                  true
+        #expect(b1==false&&i1<i2&&false==b1&&i2==1)
+                | | |    | | || | |    | | | | | |
+                | | |    | 0 |1 | |    | | | 1 | 1
+                | | |    |   |  | |    | | |   true
+                | | |    |   |  | |    | | true
+                | | |    |   |  | |    | false
+                | | |    |   |  | |    true
+                | | |    |   |  | false
+                | | |    |   |  true
+                | | |    |   true
+                | | |    true
+                | | false
+                | true
+                false
+        #expect(b1==false&&i1<i2&&false==b1&&i2==1||d1×d2==24.0)
+                | | |      |  |   |      |   |   |
+                | | false  0  1   false  |   1   1
+                | true                   false
+                false
 
         """
       )
@@ -2788,26 +2787,26 @@ final class PowerAssertTests: XCTestCase {
 //      }
 //
 //      let array = [0, 1, 2]
-//      #powerAssert(array.map { testA($0) } == [1, 2, 3], verbose: true)
-//      #powerAssert(array.map(testB) == [1, 2, 3], verbose: true)
+//      #expect(array.map { testA($0) } == [1, 2, 3], verbose: true)
+//      #expect(array.map(testB) == [1, 2, 3], verbose: true)
 //    } completion: { (output) in
 //      print(output)
 //      XCTAssertEqual(
 //        output,
 //        """
-//        #powerAssert(array.map { testA($0) } == [1, 2, 3])
-//                     |     |                 |  ||  |  |
-//                     |     [1, 2, 3]         |  |1  2  3
-//                     [0, 1, 2]               |  [1, 2, 3]
-//                                             true
-//        #powerAssert(array.map(testB) == [1, 2, 3])
-//                     |     |   |      |  ||  |  |
-//                     |     |   |      |  |1  2  3
-//                     |     |   |      |  [1, 2, 3]
-//                     |     |   |      true
-//                     |     |   (Function)
-//                     |     [1, 2, 3]
-//                     [0, 1, 2]
+//        #expect(array.map { testA($0) } == [1, 2, 3])
+//                |     |                 |  ||  |  |
+//                |     [1, 2, 3]         |  |1  2  3
+//                [0, 1, 2]               |  [1, 2, 3]
+//                                        true
+//        #expect(array.map(testB) == [1, 2, 3])
+//                |     |   |      |  ||  |  |
+//                |     |   |      |  |1  2  3
+//                |     |   |      |  [1, 2, 3]
+//                |     |   |      true
+//                |     |   (Function)
+//                |     [1, 2, 3]
+//                [0, 1, 2]
 //
 //        """
 //      )


### PR DESCRIPTION
Rename the assert function to `#expect` and leave the original `#powerAssert` function as an alias for `#expect`.