### PR TITLE
Fixed a problem where Float or Double inferences would conflict in expressions that take a Float literal as an argument, such as the #colorLiteral function.

### DIFF
--- a/Sources/PowerAssert/PowerAssert.swift
+++ b/Sources/PowerAssert/PowerAssert.swift
@@ -42,6 +42,18 @@ public enum PowerAssert {
       return val
     }
 
+    public func capture(_ expr: @autoclosure () throws -> Float, column: Int) rethrows -> Float {
+      let val = try expr()
+      store(value: val, column: column)
+      return val
+    }
+
+    public func capture(_ expr: @autoclosure () throws -> Double, column: Int) rethrows -> Double {
+      let val = try expr()
+      store(value: val, column: column)
+      return val
+    }
+
     public func store<T>(value: T, column: Int) {
       values.append(Value(value: valueToString(value), column: column))
     }

--- a/Tests/PowerAssertTests.swift
+++ b/Tests/PowerAssertTests.swift
@@ -647,55 +647,57 @@ final class PowerAssertTests: XCTestCase {
     }
   }
 
-//  func testMagicLiteralExpression() {
-//    captureConsoleOutput {
-//      #powerAssert(
-//        #file != "*.swift" && #line != 1 && #column != 2 && #function != "function",
-//        verbose: true
-//      )
-//      #powerAssert(
-//        #colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1) != .blue &&
-//          .blue != #colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1),
-//        verbose: true
-//      )
-//    } completion: { (output) in
-//      print(output)
-//      XCTAssertEqual(
-//        output,
-//        """
-//        #powerAssert(#file != "*.swift" && #line != 1 && #column != 2 && #function != "function")
-//                     |     |  |         |  |     |  | |  |       |  | |  |         |  |
-//                     |     |  "*.swift" |  2     |  1 |  467     |  2 |  |         |  "function"
-//                     |     true         true     true true       true |  |         true
-//                     |                                                |  "testMagicLiteralExpression()"
-//                     |                                                true
-//                     "@__swiftmacro_16PowerAssertTestsAAC26testMagicLiteralExpressionyyFyyXEfU_05powerB0fMf_.swift"
-//        #powerAssert(#colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1) != .blue && .blue != #colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1))
-//                     |                                                                                 |  |   |    |   |    |  |                                                                                 |
-//                     Optional(sRGB IEC61966-2.1 colorspace 0.807843 0.027451 0.333333 1)               |  |   |    |   |    |  Optional(sRGB IEC61966-2.1 colorspace 0.807843 0.027451 0.333333 1)               1.0
-//                                                                                                       |  |   |    |   |    true
-//                                                                                                       |  |   |    |   Optional(sRGB IEC61966-2.1 colorspace 0 0 1 1)
-//                                                                                                       |  |   |    true
-//                                                                                                       |  |   Optional(sRGB IEC61966-2.1 colorspace 0 0 1 1)
-//                                                                                                       |  true
-//                                                                                                       1.0
-//        #powerAssert(#file != "*.swift" && #line != 1 && #column != 2 && #function != "function")
-//                     |     |  |         |  |     |  | |  |       |  | |  |         |  |
-//                     |     |  "*.swift" |  2     |  1 |  912     |  2 |  |         |  "function"
-//                     |     true         true     true true       true |  |         true
-//                     |                                                |  "testMagicLiteralExpression()"
-//                     |                                                true
-//                     "@__swiftmacro_16PowerAssertTestsAAC26testMagicLiteralExpressionyyFyyXEfU_05powerB0fMf_.swift"
-//        #powerAssert(#colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1) != .blue && .blue != #colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1))
-//                     |                  |                    |                    |                    |  |        |        |  |                  |                    |                    |                    |
-//                     |                  0.8078431487         0.02745098062        0.3333333433         1  true     true     |  |                  0.8078431487         0.02745098062        0.3333333433         1
-//                     sRGB IEC61966-2.1 colorspace 0.807843 0.027451 0.333333 1                                              |  sRGB IEC61966-2.1 colorspace 0.807843 0.027451 0.333333 1
-//                                                                                                                            true
-//
-//        """
-//      )
-//    }
-//  }
+  func testMagicLiteralExpression1() {
+    captureConsoleOutput {
+      #expect(
+        #file != "*.swift" && #line != 1 && #column != 2 && #function != "function",
+        verbose: true
+      )
+    } completion: { (output) in
+      print(output)
+      XCTAssertEqual(
+        output,
+        """
+        #expect(#file != "*.swift" && #line != 1 && #column != 2 && #function != "function")
+                |     |  |         |  |     |  | |  |       |  | |  |         |  |
+                |     |  "*.swift" |  3     |  1 |  250     |  2 |  |         |  "function"
+                |     true         true     true true       true |  |         true
+                |                                                |  "testMagicLiteralExpression1()"
+                |                                                true
+                "@__swiftmacro_16PowerAssertTestsAAC27testMagicLiteralExpression1yyFXefU_6expectfMf_.swift"
+
+        """
+      )
+    }
+  }
+
+  func testMagicLiteralExpression2() {
+    captureConsoleOutput {
+      #expect(
+        #colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1) != .blue &&
+          .blue != #colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1),
+        verbose: true
+      )
+    } completion: { (output) in
+      print(output)
+      XCTAssertEqual(
+        output,
+        """
+        #expect(#colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1) != .blue && .blue != #colorLiteral(red: 0.8078431487, green: 0.02745098062, blue: 0.3333333433, alpha: 1))
+                |                  |                    |                    |                    |  |   |    |   |    |  |                  |                    |                    |                    |
+                |                  0.80784315           0.02745098           0.33333334           |  |   |    |   |    |  |                  0.80784315           0.02745098           0.33333334           1.0
+                sRGB IEC61966-2.1 colorspace 0.807843 0.027451 0.333333 1                         |  |   |    |   |    |  sRGB IEC61966-2.1 colorspace 0.807843 0.027451 0.333333 1
+                                                                                                  |  |   |    |   |    true
+                                                                                                  |  |   |    |   sRGB IEC61966-2.1 colorspace 0 0 1 1
+                                                                                                  |  |   |    true
+                                                                                                  |  |   sRGB IEC61966-2.1 colorspace 0 0 1 1
+                                                                                                  |  true
+                                                                                                  1.0
+
+        """
+      )
+    }
+  }
 
   func testSelfExpression() {
     captureConsoleOutput {


### PR DESCRIPTION
Fixed a problem where Float or Double inferences would conflict in expressions that take a Float literal as an argument, such as the #colorLiteral function.

```
$0.capture(#colorLiteral(red: $0.capture(0.8078431487, column: 32), green: $0.capture(0.02745098062, column: 53), blue: $0.capture(0.3333333433, column: 74), alpha: $0.capture(1, column: 95)), column: 13)

=> Conflicting arguments to generic parameter 'T' ('Double' vs. 'Float')

```