### PR TITLE
Update SwiftSyntax to the latest commit

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
         "branch" : "main",
-        "revision" : "2ee92df7093d581728063a55ed3e7c774e3ce147"
+        "revision" : "3c73cc88463aec967f4c6a2ac3e8de1f599e966a"
       }
     }
   ],

--- a/Sources/PowerAssertPlugin/PowerAssertRewriter.swift
+++ b/Sources/PowerAssertPlugin/PowerAssertRewriter.swift
@@ -18,7 +18,7 @@ class PowerAssertRewriter: SyntaxRewriter {
 
     let startLocation = macro.startLocation(converter: SourceLocationConverter(file: "", tree: macro))
     let endLocation = macro.macro.endLocation(converter: SourceLocationConverter(file: "", tree: macro))
-    startColumn = endLocation.column! - startLocation.column!
+    startColumn = endLocation.column - startLocation.column
   }
 
   func rewrite() -> SyntaxProtocol {
@@ -353,10 +353,10 @@ class PowerAssertRewriter: SyntaxRewriter {
   private func graphemeColumn(_ node: SyntaxProtocol) -> Int {
     let startLocation = node.startLocation(converter: sourceLocationConverter)
     let column: Int
-    if let graphemeClusters = String("\(expression)".utf8.prefix(startLocation.column!)) {
+    if let graphemeClusters = String("\(expression)".utf8.prefix(startLocation.column)) {
       column = stringWidth(graphemeClusters)
     } else {
-      column = startLocation.column!
+      column = startLocation.column
     }
     return column
   }

--- a/Tests/PowerAssertTests.swift
+++ b/Tests/PowerAssertTests.swift
@@ -713,7 +713,7 @@ final class PowerAssertTests: XCTestCase {
         """
         #assert(#file != "*.swift" && #line != 1 && #column != 2 && #function != "function")
                 |     |  |         |  |     |  | |  |       |  | |  |         |  |
-                |     |  "*.swift" |  3     |  1 |  250     |  2 |  |         |  "function"
+                |     |  "*.swift" |  2     |  1 |  252     |  2 |  |         |  "function"
                 |     true         true     true true       true |  |         true
                 |                                                |  "testMagicLiteralExpression1()"
                 |                                                true


### PR DESCRIPTION
SourceLocation's `line` and `column` are now non-optional.

https://github.com/apple/swift-syntax/pull/1532