### PR TITLE
Fix `error: the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions` error.

### DIFF
--- a/Sources/PowerAssert/PowerAssert.swift
+++ b/Sources/PowerAssert/PowerAssert.swift
@@ -73,6 +73,7 @@ public enum PowerAssert {
       }
     }
 
+    @_disfavoredOverload
     public func captureSync<T>(_ expr: @autoclosure () throws -> T, column: Int, id: Int) rethrows -> T {
       do {
         let val = try expr()
@@ -84,6 +85,7 @@ public enum PowerAssert {
       }
     }
 
+    @_disfavoredOverload
     public func captureAsync<T>(_ expr: @autoclosure () async throws -> T, column: Int, id: Int) async rethrows -> T {
       do {
         let val = try await expr()
@@ -390,6 +392,7 @@ extension PowerAssert.Assertion {
     }
   }
 
+  @_disfavoredOverload
   public func captureSync<T>(_ expr: @autoclosure () throws -> T?, column: Int, id: Int) rethrows -> T? {
     do {
       let val = try expr()
@@ -458,6 +461,7 @@ extension PowerAssert.Assertion {
     }
   }
 
+  @_disfavoredOverload
   public func captureAsync<T>(_ expr: @autoclosure () async throws -> T?, column: Int, id: Int) async rethrows -> T? {
     do {
       let val = try await expr()

--- a/Tests/PowerAssertTests.swift
+++ b/Tests/PowerAssertTests.swift
@@ -5110,4 +5110,51 @@ final class PowerAssertTests: XCTestCase {
       )
     }
   }
+
+  func testTypecheckTimeoutDueToOvealoading() {
+    setenv("SWIFTPOWERASSERT_NOXCTEST", "1", 1)
+    defer {
+      unsetenv("SWIFTPOWERASSERT_NOXCTEST")
+    }
+
+    captureConsoleOutput {
+      let a = 2
+      let b = 3
+      let c = 4
+      #assert((a + b) * c == 15)
+    } completion: { (output) in
+      print(output)
+      XCTAssertEqual(
+        output,
+        """
+        #assert((a + b) * c == 15)
+                ││ │ │  │ │ │  │
+                │2 5 3  │ 4 │  15
+                5       20  false
+
+        - expected + actual
+
+        --- [Int] (a + b) * c
+        +++ [Int] 15
+        –20
+        +15
+
+        [Int] a
+        => 2
+        [Int] b
+        => 3
+        [Int] (a + b)
+        => 5
+        [Int] c
+        => 4
+        [Int] (a + b) * c
+        => 20
+        [Int] 15
+        => 15
+
+
+        """
+      )
+    }
+  }
 }


### PR DESCRIPTION
Repro case:

```
let a = 2
let b = 3
let c = 4

#assert((a + b) * c == 15)
```