### PR TITLE
Use any keyword for existential types

### DIFF
--- a/Sources/PowerAssert/PowerAssert.swift
+++ b/Sources/PowerAssert/PowerAssert.swift
@@ -19,7 +19,7 @@ public enum PowerAssert {
     private var equalityExpressionValues = [EqualityExpressionValue]()
     private var identicalExpressionValues = [IdenticalExpressionValue]()
     private var comparisonValues = [ComparisonValue]()
-    private var errors = [Error]()
+    private var errors = [any Error]()
 
     public init(
       _ assertion: String,

--- a/Sources/PowerAssertPlugin/PowerAssertMacro.swift
+++ b/Sources/PowerAssertPlugin/PowerAssertMacro.swift
@@ -12,8 +12,8 @@ public struct PowerAssertMacro: ExpressionMacro {
 }
 
 private struct CodeGenerator {
-  let macro: FreestandingMacroExpansionSyntax
-  let context: MacroExpansionContext
+  let macro: any FreestandingMacroExpansionSyntax
+  let context: any MacroExpansionContext
 
   func generate() -> ExprSyntax {
     guard let assertion = macro.argumentList.first?.expression else {
@@ -29,7 +29,7 @@ private struct CodeGenerator {
     return syntax.with(\.leadingTrivia, macro.leadingTrivia)
   }
 
-  private func expand(expression: SyntaxProtocol, parameters: Parameters) -> String {
+  private func expand(expression: any SyntaxProtocol, parameters: Parameters) -> String {
     let assertion = StringLiteralExprSyntax(
       content: "\(macro.poundToken.trimmed)\(macro.macro)(\(expression))"
     )
@@ -65,7 +65,7 @@ private struct Parameters {
   var line: String
   var verbose = "false"
 
-  init(macro: FreestandingMacroExpansionSyntax, context: MacroExpansionContext) {
+  init(macro: any FreestandingMacroExpansionSyntax, context: any MacroExpansionContext) {
     let sourceLocation: AbstractSourceLocation? = context.location(of: macro)
 
     let file = "\(sourceLocation!.file)"

--- a/Sources/PowerAssertPlugin/PowerAssertPlugin.swift
+++ b/Sources/PowerAssertPlugin/PowerAssertPlugin.swift
@@ -4,7 +4,7 @@ import SwiftSyntaxMacros
 
 @main
 struct PowerAssertPlugin: CompilerPlugin {
-  let providingMacros: [Macro.Type] = [
+  let providingMacros: [any Macro.Type] = [
     PowerAssertMacro.self,
   ]
 }

--- a/Sources/PowerAssertPlugin/PowerAssertRewriter.swift
+++ b/Sources/PowerAssertPlugin/PowerAssertRewriter.swift
@@ -3,7 +3,7 @@ import SwiftOperators
 import StringWidth
 
 class PowerAssertRewriter: SyntaxRewriter {
-  private let expression: SyntaxProtocol
+  private let expression: any SyntaxProtocol
   private let sourceLocationConverter: SourceLocationConverter
   private let startColumn: Int
   private let isTryPresent: Bool
@@ -12,7 +12,7 @@ class PowerAssertRewriter: SyntaxRewriter {
   private var index = 0
   private let expressionStore = ExpressionStore()
 
-  init(_ expression: SyntaxProtocol, macro node: FreestandingMacroExpansionSyntax) {
+  init(_ expression: any SyntaxProtocol, macro node: any FreestandingMacroExpansionSyntax) {
     if let folded = try? OperatorTable.standardOperators.foldAll(expression) {
       self.expression = folded
     } else {
@@ -534,7 +534,7 @@ class PowerAssertRewriter: SyntaxRewriter {
     return exprSyntax
   }
 
-  private func findAncestors<T: SyntaxProtocol>(syntaxType: T.Type, node: SyntaxProtocol) -> T? {
+  private func findAncestors<T: SyntaxProtocol>(syntaxType: T.Type, node: any SyntaxProtocol) -> T? {
     let node = node.parent
     var cur: Syntax? = node
     while let node = cur {
@@ -546,7 +546,7 @@ class PowerAssertRewriter: SyntaxRewriter {
     return nil
   }
 
-  private func findDescendants<T: SyntaxProtocol>(syntaxType: T.Type, node: SyntaxProtocol) -> T? {
+  private func findDescendants<T: SyntaxProtocol>(syntaxType: T.Type, node: any SyntaxProtocol) -> T? {
     let children = node.children(viewMode: .fixedUp)
     for child in children {
       if child.syntaxNodeType == TokenSyntax.self {
@@ -562,7 +562,7 @@ class PowerAssertRewriter: SyntaxRewriter {
     return nil
   }
 
-  private func findLeftSiblingOperator(_ node: SyntaxProtocol) -> Bool {
+  private func findLeftSiblingOperator(_ node: any SyntaxProtocol) -> Bool {
     guard let parent = node.parent else {
       return false
     }
@@ -579,7 +579,7 @@ class PowerAssertRewriter: SyntaxRewriter {
     return false
   }
 
-  private func graphemeColumn(_ node: SyntaxProtocol) -> Int {
+  private func graphemeColumn(_ node: any SyntaxProtocol) -> Int {
     let startLocation = node.startLocation(converter: sourceLocationConverter)
     let column: Int
     if let graphemeClusters = String("\(expression)".utf8.prefix(startLocation.column)) {

--- a/Sources/PowerAssertPlugin/SingleLineFormatter.swift
+++ b/Sources/PowerAssertPlugin/SingleLineFormatter.swift
@@ -1,13 +1,13 @@
 import SwiftSyntax
 
 class SingleLineFormatter: SyntaxRewriter {
-  private let expression: SyntaxProtocol
+  private let expression: any SyntaxProtocol
 
-  init(_ expression: SyntaxProtocol) {
+  init(_ expression: any SyntaxProtocol) {
     self.expression = expression
   }
 
-  func format() -> SyntaxProtocol {
+  func format() -> any SyntaxProtocol {
     let formatted = visit(Syntax(expression).with(\.leadingTrivia, []).with(\.trailingTrivia, []))
     return SourceFileSyntax(stringLiteral: "\(formatted)")
   }

--- a/Tests/AssertTests.swift
+++ b/Tests/AssertTests.swift
@@ -3881,11 +3881,11 @@ final class AssertTests: XCTestCase {
   func testSelectorExpression() {
     captureConsoleOutput {
       #assert(
-        #selector(SomeObjCClass.doSomething(_:)) != #selector(getter: NSObjectProtocol.description),
+        #selector(SomeObjCClass.doSomething(_:)) != #selector(getter: (any NSObjectProtocol).description),
         verbose: true
       )
       #assert(
-        #selector(getter: SomeObjCClass.property) != #selector(getter: NSObjectProtocol.description),
+        #selector(getter: SomeObjCClass.property) != #selector(getter: (any NSObjectProtocol).description),
         verbose: true
       )
     } completion: { (output) in
@@ -3893,24 +3893,24 @@ final class AssertTests: XCTestCase {
       XCTAssertEqual(
         output,
         """
-        #assert(#selector(SomeObjCClass.doSomething(_:)) != #selector(getter: NSObjectProtocol.description))
+        #assert(#selector(SomeObjCClass.doSomething(_:)) != #selector(getter: (any NSObjectProtocol).description))
                 │                                        │  │
                 "doSomethingWithInt:"                    │  "description"
                                                          true
 
         [Selector] #selector(SomeObjCClass.doSomething(_:))
         => "doSomethingWithInt:"
-        [Selector] #selector(getter: NSObjectProtocol.description)
+        [Selector] #selector(getter: (any NSObjectProtocol).description)
         => "description"
 
-        #assert(#selector(getter: SomeObjCClass.property) != #selector(getter: NSObjectProtocol.description))
+        #assert(#selector(getter: SomeObjCClass.property) != #selector(getter: (any NSObjectProtocol).description))
                 │                                         │  │
                 "property"                                │  "description"
                                                           true
 
         [Selector] #selector(getter: SomeObjCClass.property)
         => "property"
-        [Selector] #selector(getter: NSObjectProtocol.description)
+        [Selector] #selector(getter: (any NSObjectProtocol).description)
         => "description"
 
 

--- a/Tests/MacroExpansionTests.swift
+++ b/Tests/MacroExpansionTests.swift
@@ -14,7 +14,7 @@ final class MacroExpansionTests: XCTestCase {
         #assert(numbers[2] == 4)
         """
     )
-    let macros: [String: Macro.Type] = [
+    let macros: [String: any Macro.Type] = [
       "assert": PowerAssertMacro.self,
     ]
     let context = BasicMacroExpansionContext(
@@ -67,7 +67,7 @@ final class MacroExpansionTests: XCTestCase {
         #assert(numbers.contains(6))
         """
     )
-    let macros: [String: Macro.Type] = [
+    let macros: [String: any Macro.Type] = [
       "assert": PowerAssertMacro.self,
     ]
     let context = BasicMacroExpansionContext(
@@ -104,7 +104,7 @@ final class MacroExpansionTests: XCTestCase {
         #assert(string1 == string2)
         """
     )
-    let macros: [String: Macro.Type] = [
+    let macros: [String: any Macro.Type] = [
       "assert": PowerAssertMacro.self,
     ]
     let context = BasicMacroExpansionContext(


### PR DESCRIPTION
Since `any` keyword for existential types [will be required in Swift 6](https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md#transitioning-to-any-in-swift-6), I think it would be good to apply it from now on.
