### PR TITLE
String? rendering issue from #384: add test and access to PowerAssert.stringify

### DIFF
--- a/Sources/PowerAssert/PowerAssert.swift
+++ b/Sources/PowerAssert/PowerAssert.swift
@@ -524,3 +524,12 @@ extension PowerAssert.Assertion {
     }
   }
 }
+
+extension PowerAssert {
+  /// Test-only access to private ``PowerAssert`` members
+  enum TestOnlyAccess {
+    static func stringify<T>(_ value: T?) -> String {
+      PowerAssert.stringify(value)
+    }
+  }
+}

--- a/Tests/BugFixTests.swift
+++ b/Tests/BugFixTests.swift
@@ -1,0 +1,50 @@
+
+import Foundation
+import XCTest
+@testable import PowerAssert
+
+final class BugFixTests: XCTestCase {
+
+  /// Baseline behavior for comparison with Optional(Int)
+  func testOptionalIntRendering() {
+    func test<T>(_ item: T?) -> String {
+      PowerAssert.TestOnlyAccess.stringify(item)
+    }
+    let i: Int = 1
+    let oiOne: Int? = i
+    let ooiOptOne: (Int?)? = oiOne
+    let oiNil: Int? = nil
+    let ooiNil: (Int?)? = oiNil
+    let ooiOptNil: (Int?)? = ooiNil
+    XCTAssertEqual("1", test(i))
+    XCTAssertEqual("1", test(oiOne))
+    XCTAssertEqual(#"Optional(1)"#, test(ooiOptOne)) // current, correct
+
+    // Wrappers all reduced to nil?
+    XCTAssertEqual("nil", test(oiNil))
+    XCTAssertEqual("nil", test(ooiNil))
+    XCTAssertEqual("nil", test(ooiOptNil))
+  }
+
+  /// Optional(String) gets quoted?
+  func testOptionalStringRendering() {
+    func test<T>(_ item: T?) -> String {
+      PowerAssert.TestOnlyAccess.stringify(item)
+    }
+    let s: String = "s"
+    let osStr: String? = s
+    let oosOptStr: (String?)? = osStr
+    let osNil: String? = nil
+    let oosNil: (String?)? = osNil
+    let oosOptNil: (String?)? = oosNil
+    XCTAssertEqual(#""s""#, test(s))
+    XCTAssertEqual(#""s""#, test(osStr))
+    XCTAssertEqual(#""Optional(\"s\")""#, test(oosOptStr)) // current
+    //XCTAssertEqual("Optional(\"s\")", test(oosOptStr)) // correct?
+
+    // Wrappers all reduced to nil?
+    XCTAssertEqual("nil", test(osNil))
+    XCTAssertEqual("nil", test(oosNil))
+    XCTAssertEqual("nil", test(oosOptNil))
+  }
+}


### PR DESCRIPTION
PR #384 reported an issue with `"Optional(\"s\")"` rendering of optional string, where the outer quotes seem incorrect.

If that should be fixed or the behavior accepted and verified, these tests should help.  They now accept the current behavior.

The tests also raise the question about nil values in n>1 layers of optional wrapping:  "nil" is used whether the value is T? or (T?)?.

The `String?` problem seems to be in the `stringify` check `where v is String`, which returns true for a non-nil `Optional<String>` or  `Optional<Optional<String>>`.

In both cases, I don't understand enough yet to evaluate the consequences of a fix, so this PR does not propose a fix.
